### PR TITLE
Forman improve ts zoom

### DIFF
--- a/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
@@ -81,11 +81,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface TimeRangeSelection {
-  firstTime?: number;
-  secondTime?: number;
-
-  firstValue?: number;
-  secondValue?: number;
+  time1?: number;
+  value1?: number;
+  time2?: number;
+  value2?: number;
 }
 
 interface TimeSeriesChartProps extends WithLocale {
@@ -206,12 +205,10 @@ export default function TimeSeriesChart({
     if (!isNumber(chartX) || !isNumber(chartY)) {
       return;
     }
-    const firstTime = chartState.activeLabel;
-    const chartCoords = getChartCoords(chartX, chartY);
-    if (isNumber(firstTime) && chartCoords) {
-      // Actually we should use firstTime=chartCoords[0] but recharts cannot clip
-      // correctly
-      setTimeRangeSelection({ firstTime, firstValue: chartCoords[1] });
+    const point1 = getChartCoords(chartX, chartY);
+    if (point1) {
+      const [time1, value1] = point1;
+      setTimeRangeSelection({ time1, value1 });
     }
   };
 
@@ -219,8 +216,8 @@ export default function TimeSeriesChart({
     chartState: CategoricalChartState | CategoricalChartState_Fixed | null,
     mouseEvent: MouseEvent<HTMLElement>,
   ) => {
-    const firstTime = timeRangeSelection.firstTime;
-    if (firstTime === undefined) {
+    const { time1, value1 } = timeRangeSelection;
+    if (!isNumber(time1) || !isNumber(value1)) {
       return;
     }
     if (!chartState) {
@@ -230,19 +227,21 @@ export default function TimeSeriesChart({
     if (!isNumber(chartX) || !isNumber(chartY)) {
       return;
     }
-    const secondTime = chartState.activeLabel;
-    const chartCoords = getChartCoords(chartX, chartY);
-    if (isNumber(secondTime) && chartCoords) {
+    const point2 = getChartCoords(chartX, chartY);
+    if (point2) {
+      const [time2, value2] = point2;
       if (mouseEvent.ctrlKey) {
         setTimeRangeSelection({
-          ...timeRangeSelection,
-          secondTime,
-          secondValue: chartCoords[1],
+          time1,
+          value1,
+          time2,
+          value2,
         });
       } else {
         setTimeRangeSelection({
-          ...timeRangeSelection,
-          secondTime,
+          time1,
+          value1,
+          time2,
         });
       }
     }
@@ -265,41 +264,22 @@ export default function TimeSeriesChart({
   };
 
   const zoomIn = () => {
-    const { firstTime, secondTime, firstValue, secondValue } =
-      timeRangeSelection;
-    if (
-      firstTime === secondTime ||
-      firstTime === undefined ||
-      secondTime === undefined
-    ) {
-      clearTimeRangeSelection();
-      return;
-    }
-    let timeRange: [number, number];
-    if (firstTime < secondTime) {
-      timeRange = [firstTime, secondTime];
-    } else {
-      timeRange = [secondTime, firstTime];
-    }
-    let valueRange: [number, number] | undefined = undefined;
-    if (firstValue !== undefined && secondValue !== undefined) {
-      if (firstValue < secondValue) {
-        valueRange = [firstValue, secondValue];
+    const [selectedXRange, selectedYRange] =
+      normalizeTimeRangeSelection(timeRangeSelection);
+    if (selectedXRange && selectedXRange[0] < selectedXRange[1]) {
+      if (selectedYRange) {
+        selectTimeRange(selectedXRange, timeSeriesGroup.id, selectedYRange);
       } else {
-        valueRange = [secondValue, firstValue];
+        selectTimeRange(selectedXRange, timeSeriesGroup.id, null);
       }
-    }
-    clearTimeRangeSelection();
-    if (selectTimeRange) {
-      selectTimeRange(timeRange, timeSeriesGroup.id, valueRange);
+    } else {
+      clearTimeRangeSelection();
     }
   };
 
   const resetZoom = () => {
     clearTimeRangeSelection();
-    if (selectTimeRange) {
-      selectTimeRange(dataTimeRange || null, timeSeriesGroup.id, null);
-    }
+    selectTimeRange(dataTimeRange || null, timeSeriesGroup.id, null);
   };
 
   const handleChartResize = (w: number, h: number) => {
@@ -372,7 +352,8 @@ export default function TimeSeriesChart({
     return [xMin + wx * (xMax - xMin), yMax - wy * (yMax - yMin)];
   };
 
-  const { firstTime, secondTime, firstValue, secondValue } = timeRangeSelection;
+  const [selectedXRange, selectedYRange] =
+    normalizeTimeRangeSelection(timeRangeSelection);
 
   return (
     <div ref={containerRef} className={classes.chartContainer}>
@@ -387,7 +368,7 @@ export default function TimeSeriesChart({
       />
       <ResponsiveContainer
         // 99% per https://github.com/recharts/recharts/issues/172
-        width="99%"
+        width="98%"
         className={classes.responsiveContainer}
         onResize={handleChartResize}
       >
@@ -420,7 +401,7 @@ export default function TimeSeriesChart({
             allowDataOverflow
           />
           <CartesianGrid strokeDasharray="3 3" />
-          {!timeRangeSelection.firstTime && (
+          {!isNumber(timeRangeSelection.time1) && (
             <Tooltip content={<CustomTooltip />} />
           )}
           <Legend
@@ -446,20 +427,12 @@ export default function TimeSeriesChart({
               paletteMode: theme.palette.mode,
             }),
           )}
-          {isNumber(firstTime) && isNumber(secondTime) && (
+          {selectedXRange && (
             <ReferenceArea
-              x1={firstTime}
-              y1={
-                isNumber(firstValue) && isNumber(secondValue)
-                  ? firstValue
-                  : undefined
-              }
-              x2={secondTime}
-              y2={
-                isNumber(firstValue) && isNumber(secondValue)
-                  ? secondValue
-                  : undefined
-              }
+              x1={selectedXRange[0]}
+              y1={selectedYRange ? selectedYRange[0] : undefined}
+              x2={selectedXRange[1]}
+              y2={selectedYRange ? selectedYRange[1] : undefined}
               strokeOpacity={0.3}
               fill={lightStroke}
               fillOpacity={0.3}
@@ -478,4 +451,17 @@ export default function TimeSeriesChart({
       </ResponsiveContainer>
     </div>
   );
+}
+
+function normalizeTimeRangeSelection(timeRangeSelection: TimeRangeSelection) {
+  const { time1, time2, value1, value2 } = timeRangeSelection;
+  let timeRange: [number, number] | undefined = undefined;
+  let valueRange: [number, number] | undefined = undefined;
+  if (isNumber(time1) && isNumber(time2)) {
+    timeRange = time1 < time2 ? [time1, time2] : [time2, time1];
+    if (isNumber(value1) && isNumber(value2)) {
+      valueRange = value1 < value2 ? [value1, value2] : [value2, value1];
+    }
+  }
+  return [timeRange, valueRange];
 }

--- a/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
@@ -49,12 +49,15 @@ import {
   TimeSeriesPoint,
 } from "@/model/timeSeries";
 import { WithLocale } from "@/util/lang";
-import { utcTimeToIsoDateString } from "@/util/time";
 import CustomLegend from "./CustomLegend";
 import CustomTooltip from "./CustomTooltip";
 import TimeSeriesLine from "@/components/TimeSeriesCharts/TimeSeriesLine";
 import TimeSeriesChartHeader from "@/components/TimeSeriesCharts/TimeSeriesChartHeader";
 import { isNumber } from "@/util/types";
+import {
+  formatTimeTick,
+  formatValueTick,
+} from "@/components/TimeSeriesCharts/util";
 
 // Fix typing problem in recharts v2.12.4
 type CategoricalChartState_Fixed = Omit<
@@ -177,13 +180,6 @@ export default function TimeSeriesChart({
 
   const clearTimeRangeSelection = () => {
     setTimeRangeSelection({});
-  };
-
-  const formatTimeTick = (value: number | string) => {
-    if (!isNumber(value) || !Number.isFinite(value)) {
-      return "";
-    }
-    return utcTimeToIsoDateString(value);
   };
 
   const handleClick = (
@@ -412,17 +408,16 @@ export default function TimeSeriesChart({
             domain={getXDomain}
             tickFormatter={formatTimeTick}
             stroke={labelTextColor}
-            allowDuplicatedCategory={false}
+            allowDataOverflow
           />
           <YAxis
             dataKey={commonValueDataKey || "mean"}
             type="number"
             tickCount={5}
             domain={getYDomain}
-            tickFormatter={(value: number) => {
-              return value.toFixed(2);
-            }}
+            tickFormatter={formatValueTick}
             stroke={labelTextColor}
+            allowDataOverflow
           />
           <CartesianGrid strokeDasharray="3 3" />
           {!timeRangeSelection.firstTime && (

--- a/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
@@ -417,7 +417,6 @@ export default function TimeSeriesChart({
               timeSeriesGroup,
               timeSeriesIndex,
               selectTimeSeries,
-              selectedTimeRange,
               showPointsOnly,
               showErrorBars,
               places,

--- a/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
@@ -28,10 +28,8 @@ import { getUserPlaceColor } from "@/config";
 import { Place, PlaceInfo } from "@/model/place";
 import {
   PlaceGroupTimeSeries,
-  TimeRange,
   TimeSeries,
   TimeSeriesGroup,
-  TimeSeriesPoint,
 } from "@/model/timeSeries";
 import CustomDot from "./CustomDot";
 import { PaletteMode } from "@mui/material";
@@ -41,7 +39,6 @@ interface TimeSeriesLineProps {
   timeSeriesIndex: number;
   showPointsOnly: boolean;
   showErrorBars: boolean;
-  selectedTimeRange: TimeRange | null;
   // Not implemented yet
   selectTimeSeries?: (
     timeSeriesGroupId: string,
@@ -62,7 +59,6 @@ interface TimeSeriesLineProps {
 export default function TimeSeriesLine({
   timeSeriesGroup,
   timeSeriesIndex,
-  selectedTimeRange,
   showErrorBars,
   showPointsOnly,
   selectTimeSeries,
@@ -80,8 +76,6 @@ export default function TimeSeriesLine({
     }
     selectPlace(timeSeries.source.placeId, places, true);
   };
-
-  const [time1, time2] = selectedTimeRange ? selectedTimeRange : [null, null];
 
   const source = timeSeries.source;
   const valueDataKey = source.valueDataKey;
@@ -117,35 +111,7 @@ export default function TimeSeriesLine({
     }
   }
 
-  const data: TimeSeriesPoint[] = [];
-  timeSeries.data.forEach((point) => {
-    if (point[valueDataKey] !== null) {
-      let time1Ok = true;
-      let time2Ok = true;
-      if (time1 !== null) {
-        time1Ok = point.time >= time1;
-      }
-      if (time2 !== null) {
-        time2Ok = point.time <= time2;
-      }
-      if (time1Ok && time2Ok) {
-        data.push(point);
-      }
-    }
-  });
-
   const shadedLineColor = getUserPlaceColor(lineColor, paletteMode);
-  let errorBar;
-  if (valueDataKey && showErrorBars && source.errorDataKey) {
-    errorBar = (
-      <ErrorBar
-        dataKey={source.errorDataKey}
-        width={4}
-        strokeWidth={1}
-        stroke={shadedLineColor}
-      />
-    );
-  }
 
   let strokeOpacity;
   let dotProps: {
@@ -169,22 +135,18 @@ export default function TimeSeriesLine({
     };
   }
 
-  const dot = (
-    <CustomDot {...dotProps} stroke={shadedLineColor} fill={"white"} />
-  );
-  const activeDot = (
-    <CustomDot {...dotProps} stroke={"white"} fill={shadedLineColor} />
-  );
-
   return (
     <Line
+      key={timeSeriesIndex}
       type="monotone"
       name={lineName}
       unit={source.variableUnits}
-      data={data}
+      data={timeSeries.data}
       dataKey={valueDataKey}
-      dot={dot}
-      activeDot={activeDot}
+      dot={<CustomDot {...dotProps} stroke={shadedLineColor} fill={"white"} />}
+      activeDot={
+        <CustomDot {...dotProps} stroke={"white"} fill={shadedLineColor} />
+      }
       stroke={shadedLineColor}
       strokeOpacity={strokeOpacity}
       // strokeWidth={2 * (ts.dataProgress || 1)}
@@ -193,7 +155,14 @@ export default function TimeSeriesLine({
       isAnimationActive={false}
       onClick={handleClick}
     >
-      {errorBar}
+      {valueDataKey && showErrorBars && source.errorDataKey && (
+        <ErrorBar
+          dataKey={source.errorDataKey}
+          width={4}
+          strokeWidth={1}
+          stroke={shadedLineColor}
+        />
+      )}
     </Line>
   );
 }

--- a/src/components/TimeSeriesCharts/util.ts
+++ b/src/components/TimeSeriesCharts/util.ts
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { isNumber } from "@/util/types";
+import { utcTimeToIsoDateString } from "@/util/time";
+
+export const formatTimeTick = (value: number | string) => {
+  if (!isNumber(value) || !Number.isFinite(value)) {
+    return "";
+  }
+  return utcTimeToIsoDateString(value);
+};
+
+export const formatValueTick = (value: number) => {
+  return value.toPrecision(3);
+};


### PR DESCRIPTION
Fixed numerous issues with the new y-axis zoom. Now

- allowing for arbitrary zoom region, no longer snap to actual data points 
- clipping time series lines against x- and y- axes
- no longer filtering out time series values outside the selected time range, but filtering out `nan`s instead
