### PR TITLE
Change chart type (point, line, bars) and toggle showing standard deviation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,10 @@
     by pressing the `CTRL` key of the keyboard. (#285)
   - It is now possible to toggle showing the info popup when hovering 
     over the chart.
-  - It is now possible to toggle between showing bar or line charts.
+  - User can fix the y-range of the chart by entering min and max values.
+  - Users can now change the chart type (point, line, bars) and toggle 
+    showing standard deviation directly from the time-series chart's action 
+    bar.
 
 * Introduced layer visibility dropdown menu in the control bar.
 

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -443,8 +443,8 @@ export function addTimeSeries() {
     const selectedPlaceId = selectedPlaceIdSelector(getState());
     const selectedPlace = selectedPlaceSelector(getState())!;
     const timeSeriesUpdateMode = getState().controlState.timeSeriesUpdateMode;
-    const useMedian = getState().controlState.showTimeSeriesMedian;
-    const inclStDev = getState().controlState.showTimeSeriesErrorBars;
+    const useMedian = getState().controlState.timeSeriesUseMedian;
+    const includeStdev = getState().controlState.timeSeriesIncludeStdev;
     let timeChunkSize = selectedTimeChunkSizeSelector(getState());
 
     const placeGroups = placeGroupsSelector(getState());
@@ -476,7 +476,7 @@ export function addTimeSeries() {
           startDateLabel,
           endDateLabel,
           useMedian,
-          inclStDev,
+          includeStdev,
           getState().userAuthState.accessToken,
         );
       };

--- a/src/api/getTimeSeries.ts
+++ b/src/api/getTimeSeries.ts
@@ -49,7 +49,7 @@ export function getTimeSeriesForGeometry(
   startDate: string | null,
   endDate: string | null,
   useMedian: boolean,
-  inclStDev: boolean,
+  includeStdev: boolean,
   accessToken: string | null,
 ): Promise<TimeSeries | null> {
   let valueDataKey: keyof TimeSeriesPoint;
@@ -58,7 +58,7 @@ export function getTimeSeriesForGeometry(
   if (useMedian) {
     query.push(["aggMethods", "median"]);
     valueDataKey = "median";
-  } else if (inclStDev) {
+  } else if (includeStdev) {
     query.push(["aggMethods", "mean,std"]);
     valueDataKey = "mean";
     errorDataKey = "std";

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -40,6 +40,7 @@ import {
   TIME_ANIMATION_INTERVALS,
   ControlState,
   LocateMode,
+  TimeSeriesChartType,
   TimeAnimationInterval,
 } from "@/states/controlState";
 import { GEOGRAPHIC_CRS, WEB_MERCATOR_CRS } from "@/model/proj";
@@ -72,9 +73,15 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const LOCATE_MODE_LABELS: [LocateMode, string][] = [
-  ["doNothing", "do nothing"],
-  ["pan", "pan"],
-  ["panAndZoom", "pan and zoom"],
+  ["doNothing", "Do nothing"],
+  ["pan", "Pan"],
+  ["panAndZoom", "Pan and zoom"],
+];
+
+const TS_CHART_TYPE_LABELS: [TimeSeriesChartType, string][] = [
+  ["point", "Points"],
+  ["line", "Lines"],
+  ["bar", "Bars"],
 ];
 
 interface SettingsDialogProps {
@@ -144,6 +151,14 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
       timeAnimationInterval: parseInt(
         event.target.value,
       ) as TimeAnimationInterval,
+    });
+  }
+
+  function handleTimeSeriesChartTypeDefaultChange(
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    updateSettings({
+      timeSeriesChartTypeDefault: event.target.value as TimeSeriesChartType,
     });
   }
 
@@ -278,15 +293,21 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 updateSettings={updateSettings}
               />
             </SettingsSubPanel>
-            <SettingsSubPanel
-              label={i18n.get("Show dots only, hide lines")}
-              value={getOnOff(settings.showTimeSeriesPointsOnly)}
-            >
-              <ToggleSetting
-                propertyName={"showTimeSeriesPointsOnly"}
-                settings={settings}
-                updateSettings={updateSettings}
-              />
+            <SettingsSubPanel label={i18n.get("Default chart type")}>
+              <TextField
+                variant="standard"
+                select
+                className={classes.textField}
+                value={settings.timeSeriesChartTypeDefault}
+                onChange={handleTimeSeriesChartTypeDefaultChange}
+                margin="normal"
+              >
+                {TS_CHART_TYPE_LABELS.map(([value, label]) => (
+                  <MenuItem key={value} value={value}>
+                    {i18n.get(label)}
+                  </MenuItem>
+                ))}
+              </TextField>
             </SettingsSubPanel>
             <SettingsSubPanel
               label={i18n.get("Show error bars")}
@@ -377,7 +398,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
               >
                 {LOCATE_MODE_LABELS.map(([value, label]) => (
                   <MenuItem key={value} value={value}>
-                    {label}
+                    {i18n.get(label)}
                   </MenuItem>
                 ))}
               </TextField>
@@ -393,7 +414,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
               >
                 {LOCATE_MODE_LABELS.map(([value, label]) => (
                   <MenuItem key={value} value={value}>
-                    {label}
+                    {i18n.get(label)}
                   </MenuItem>
                 ))}
               </TextField>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -284,7 +284,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
 
           <SettingsPanel title={i18n.get("Time-Series")}>
             <SettingsSubPanel
-              label={i18n.get("Show graph after adding a place")}
+              label={i18n.get("Show chart after adding a place")}
               value={getOnOff(settings.autoShowTimeSeries)}
             >
               <ToggleSetting
@@ -310,23 +310,23 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
               </TextField>
             </SettingsSubPanel>
             <SettingsSubPanel
-              label={i18n.get("Show error bars")}
-              value={getOnOff(settings.showTimeSeriesErrorBars)}
+              label={i18n.get("Calculate standard deviation")}
+              value={getOnOff(settings.timeSeriesIncludeStdev)}
             >
               <ToggleSetting
-                propertyName={"showTimeSeriesErrorBars"}
+                propertyName={"timeSeriesIncludeStdev"}
                 settings={settings}
                 updateSettings={updateSettings}
               />
             </SettingsSubPanel>
             <SettingsSubPanel
               label={i18n.get(
-                "Show median instead of mean (disables error bars)",
+                "Calculate median instead of mean (disables standard deviation)",
               )}
-              value={getOnOff(settings.showTimeSeriesMedian)}
+              value={getOnOff(settings.timeSeriesUseMedian)}
             >
               <ToggleSetting
-                propertyName={"showTimeSeriesMedian"}
+                propertyName={"timeSeriesUseMedian"}
                 settings={settings}
                 updateSettings={updateSettings}
               />

--- a/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
@@ -50,15 +50,13 @@ import {
   TimeSeriesPoint,
 } from "@/model/timeSeries";
 import { WithLocale } from "@/util/lang";
+import { TimeSeriesChartType } from "@/states/controlState";
+import { isNumber } from "@/util/types";
+import { formatTimeTick, formatValueTick } from "./util";
 import CustomLegend from "./CustomLegend";
 import CustomTooltip from "./CustomTooltip";
-import TimeSeriesLine from "@/components/TimeSeriesCharts/TimeSeriesLine";
-import TimeSeriesChartHeader from "@/components/TimeSeriesCharts/TimeSeriesChartHeader";
-import { isNumber } from "@/util/types";
-import {
-  formatTimeTick,
-  formatValueTick,
-} from "@/components/TimeSeriesCharts/util";
+import TimeSeriesLine from "./TimeSeriesLine";
+import TimeSeriesChartHeader from "./TimeSeriesChartHeader";
 
 // Fix typing problem in recharts v2.12.4
 type CategoricalChartState_Fixed = Omit<
@@ -102,7 +100,7 @@ interface TimeSeriesChartProps extends WithLocale {
     groupId?: string,
     valueRange?: [number, number] | null,
   ) => void;
-  showPointsOnly: boolean;
+  chartTypeDefault: TimeSeriesChartType;
   showErrorBars: boolean;
   // Not implemented yet
   selectTimeSeries?: (
@@ -141,7 +139,7 @@ export default function TimeSeriesChart({
   placeInfos,
   dataTimeRange,
   showErrorBars,
-  showPointsOnly,
+  chartTypeDefault,
   removeTimeSeries,
   removeTimeSeriesGroup,
   placeGroupTimeSeries,
@@ -154,7 +152,7 @@ export default function TimeSeriesChart({
 
   const [zoomMode, setZoomMode] = useState(false);
   const [showTooltips, setShowTooltips] = useState(true);
-  const [showBarChart, setShowBarChart] = useState(false);
+  const [chartType, setChartType] = useState(chartTypeDefault);
   const [zoomRectangle, setZoomRectangle] = useState<Rectangle>({});
   const xDomain = useRef<[number, number]>();
   const yDomain = useRef<[number, number]>();
@@ -402,7 +400,7 @@ export default function TimeSeriesChart({
   const [selectedXRange, selectedYRange] =
     normalizeZoomRectangle(zoomRectangle);
 
-  const ChartComponent = showBarChart ? BarChart : LineChart;
+  const ChartComponent = chartType ? BarChart : LineChart;
 
   return (
     <div ref={containerRef} className={classes.chartContainer}>
@@ -418,8 +416,8 @@ export default function TimeSeriesChart({
         setZoomMode={setZoomMode}
         showTooltips={showTooltips}
         setShowTooltips={setShowTooltips}
-        showBarChart={showBarChart}
-        setShowBarChart={setShowBarChart}
+        chartType={chartType}
+        setChartType={setChartType}
         valueRange={yDomain.current}
         setValueRange={handleEnteredValueRange}
       />
@@ -477,14 +475,13 @@ export default function TimeSeriesChart({
               timeSeriesGroup,
               timeSeriesIndex,
               selectTimeSeries,
-              showPointsOnly,
               showErrorBars,
               places,
               selectPlace,
               placeGroupTimeSeries,
               placeInfos,
+              chartType,
               paletteMode: theme.palette.mode,
-              showBarChart,
             }),
           )}
           {selectedXRange && (

--- a/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChart.tsx
@@ -101,7 +101,7 @@ interface TimeSeriesChartProps extends WithLocale {
     valueRange?: [number, number] | null,
   ) => void;
   chartTypeDefault: TimeSeriesChartType;
-  showErrorBars: boolean;
+  includeStdev: boolean;
   // Not implemented yet
   selectTimeSeries?: (
     timeSeriesGroupId: string,
@@ -138,8 +138,8 @@ export default function TimeSeriesChart({
   selectPlace,
   placeInfos,
   dataTimeRange,
-  showErrorBars,
   chartTypeDefault,
+  includeStdev,
   removeTimeSeries,
   removeTimeSeriesGroup,
   placeGroupTimeSeries,
@@ -153,6 +153,7 @@ export default function TimeSeriesChart({
   const [zoomMode, setZoomMode] = useState(false);
   const [showTooltips, setShowTooltips] = useState(true);
   const [chartType, setChartType] = useState(chartTypeDefault);
+  const [stdevBars, setStdevBars] = useState(includeStdev);
   const [zoomRectangle, setZoomRectangle] = useState<Rectangle>({});
   const xDomain = useRef<[number, number]>();
   const yDomain = useRef<[number, number]>();
@@ -400,7 +401,7 @@ export default function TimeSeriesChart({
   const [selectedXRange, selectedYRange] =
     normalizeZoomRectangle(zoomRectangle);
 
-  const ChartComponent = chartType ? BarChart : LineChart;
+  const ChartComponent = chartType === "bar" ? BarChart : LineChart;
 
   return (
     <div ref={containerRef} className={classes.chartContainer}>
@@ -418,6 +419,9 @@ export default function TimeSeriesChart({
         setShowTooltips={setShowTooltips}
         chartType={chartType}
         setChartType={setChartType}
+        stdevBarsDisabled={!includeStdev}
+        stdevBars={stdevBars}
+        setStdevBars={setStdevBars}
         valueRange={yDomain.current}
         setValueRange={handleEnteredValueRange}
       />
@@ -475,12 +479,12 @@ export default function TimeSeriesChart({
               timeSeriesGroup,
               timeSeriesIndex,
               selectTimeSeries,
-              showErrorBars,
               places,
               selectPlace,
               placeGroupTimeSeries,
               placeInfos,
               chartType,
+              stdevBars,
               paletteMode: theme.palette.mode,
             }),
           )}

--- a/src/components/TimeSeriesCharts/TimeSeriesChartHeader.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesChartHeader.tsx
@@ -27,6 +27,7 @@ import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import AspectRatioIcon from "@mui/icons-material/AspectRatio";
@@ -35,6 +36,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import CommentIcon from "@mui/icons-material/Comment";
 import ExpandIcon from "@mui/icons-material/Expand";
 import FitScreenIcon from "@mui/icons-material/FitScreen";
+import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
+import ShowChartIcon from "@mui/icons-material/ShowChart";
 
 import i18n from "@/i18n";
 import {
@@ -43,9 +46,10 @@ import {
   TimeSeriesGroup,
 } from "@/model/timeSeries";
 import { WithLocale } from "@/util/lang";
+import { makeStyles } from "@/util/styles";
+import { TimeSeriesChartType } from "@/states/controlState";
 import TimeSeriesAddButton from "./TimeSeriesAddButton";
 import ValueRangeEditor from "./ValueRangeEditor";
-import { makeStyles } from "@/util/styles";
 
 type ValueRange = [number, number];
 
@@ -75,6 +79,10 @@ const styles = makeStyles({
     fontSize: "inherit",
     fontWeight: "normal",
   },
+  chartTypes: (theme) => ({
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  }),
 });
 
 interface TimeSeriesChartHeaderProps extends WithLocale {
@@ -92,8 +100,8 @@ interface TimeSeriesChartHeaderProps extends WithLocale {
   setZoomMode: (zoomMode: boolean) => void;
   showTooltips: boolean;
   setShowTooltips: (showTooltips: boolean) => void;
-  showBarChart: boolean;
-  setShowBarChart: (barChart: boolean) => void;
+  chartType: TimeSeriesChartType;
+  setChartType: (chartType: TimeSeriesChartType) => void;
   valueRange: ValueRange | undefined;
   setValueRange: (fixedValueRange: ValueRange | undefined) => void;
 }
@@ -110,8 +118,8 @@ export default function TimeSeriesChartHeader({
   setZoomMode,
   showTooltips,
   setShowTooltips,
-  showBarChart,
-  setShowBarChart,
+  chartType,
+  setChartType,
   valueRange,
   setValueRange,
 }: TimeSeriesChartHeaderProps) {
@@ -130,6 +138,13 @@ export default function TimeSeriesChartHeader({
     if (valueRange) {
       setValueRange(valueRange);
     }
+  };
+
+  const handleChartTypeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    value: string,
+  ) => {
+    setChartType(value as TimeSeriesChartType);
   };
 
   return (
@@ -184,19 +199,26 @@ export default function TimeSeriesChartHeader({
             <CommentIcon fontSize="inherit" />
           </ToggleButton>
         </Tooltip>
-        <Tooltip
-          arrow
-          title={i18n.get("Toggle between showing a bar or line chart")}
-        >
-          <ToggleButton
-            value={"showBarChart"}
-            selected={showBarChart}
-            onClick={() => setShowBarChart(!showBarChart)}
+
+        <Tooltip arrow title={i18n.get("Select chart type")}>
+          <ToggleButtonGroup
+            value={chartType}
+            onChange={handleChartTypeChange}
             size="small"
+            sx={styles.chartTypes}
           >
-            <BarChartIcon fontSize="inherit" />
-          </ToggleButton>
+            <ToggleButton value="point" size="small">
+              <ScatterPlotIcon fontSize="inherit" />
+            </ToggleButton>
+            <ToggleButton value="line" size="small">
+              <ShowChartIcon fontSize="inherit" />
+            </ToggleButton>
+            <ToggleButton value="bar" size="small">
+              <BarChartIcon fontSize="inherit" />
+            </ToggleButton>
+          </ToggleButtonGroup>
         </Tooltip>
+
         <TimeSeriesAddButton
           sx={styles.actionButton}
           timeSeriesGroupId={timeSeriesGroup.id}

--- a/src/components/TimeSeriesCharts/TimeSeriesCharts.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesCharts.tsx
@@ -54,7 +54,7 @@ interface TimeSeriesChartsProps extends WithLocale {
   selectedTime: Time | null;
   selectTime: (time: Time | null) => void;
   chartTypeDefault: TimeSeriesChartType;
-  showErrorBars: boolean;
+  includeStdev: boolean;
   dataTimeRange: TimeRange | null;
   selectedTimeRange: TimeRange | null;
   selectTimeRange: (

--- a/src/components/TimeSeriesCharts/TimeSeriesCharts.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesCharts.tsx
@@ -34,6 +34,7 @@ import {
   TimeSeries,
   TimeSeriesGroup,
 } from "@/model/timeSeries";
+import { TimeSeriesChartType } from "@/states/controlState";
 import TimeRangeSlider from "./TimeRangeSlider";
 import TimeSeriesChart from "./TimeSeriesChart";
 
@@ -52,7 +53,7 @@ interface TimeSeriesChartsProps extends WithLocale {
   timeSeriesGroups: TimeSeriesGroup[];
   selectedTime: Time | null;
   selectTime: (time: Time | null) => void;
-  showPointsOnly: boolean;
+  chartTypeDefault: TimeSeriesChartType;
   showErrorBars: boolean;
   dataTimeRange: TimeRange | null;
   selectedTimeRange: TimeRange | null;

--- a/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
@@ -32,12 +32,12 @@ import {
   TimeSeries,
   TimeSeriesGroup,
 } from "@/model/timeSeries";
+import { TimeSeriesChartType } from "@/states/controlState";
 import CustomDot from "./CustomDot";
 
 interface TimeSeriesLineProps {
   timeSeriesGroup: TimeSeriesGroup;
   timeSeriesIndex: number;
-  showPointsOnly: boolean;
   showErrorBars: boolean;
   // Not implemented yet
   selectTimeSeries?: (
@@ -54,21 +54,20 @@ interface TimeSeriesLineProps {
   placeInfos: { [placeId: string]: PlaceInfo };
   placeGroupTimeSeries: PlaceGroupTimeSeries[];
   paletteMode: PaletteMode;
-  showBarChart: boolean;
+  chartType: TimeSeriesChartType;
 }
 
 export default function TimeSeriesLine({
   timeSeriesGroup,
   timeSeriesIndex,
   showErrorBars,
-  showPointsOnly,
   selectTimeSeries,
   places,
   selectPlace,
   placeInfos,
   placeGroupTimeSeries,
   paletteMode,
-  showBarChart,
+  chartType,
 }: TimeSeriesLineProps) {
   // WARNING: we cannot use hooks here, as this is not a normal component!
   // See usage in TimeSeriesChart component.
@@ -131,7 +130,7 @@ export default function TimeSeriesLine({
       symbol: "diamond",
     };
   } else {
-    strokeOpacity = showPointsOnly ? 0 : timeSeries.dataProgress;
+    strokeOpacity = chartType === "point" ? 0 : timeSeries.dataProgress;
     dotProps = {
       radius: 3,
       strokeWidth: 2,
@@ -151,7 +150,7 @@ export default function TimeSeriesLine({
       />
     );
 
-  return showBarChart ? (
+  return chartType === "bar" ? (
     <Bar
       key={timeSeriesIndex}
       type="monotone"

--- a/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
+++ b/src/components/TimeSeriesCharts/TimeSeriesLine.tsx
@@ -38,7 +38,6 @@ import CustomDot from "./CustomDot";
 interface TimeSeriesLineProps {
   timeSeriesGroup: TimeSeriesGroup;
   timeSeriesIndex: number;
-  showErrorBars: boolean;
   // Not implemented yet
   selectTimeSeries?: (
     timeSeriesGroupId: string,
@@ -55,12 +54,12 @@ interface TimeSeriesLineProps {
   placeGroupTimeSeries: PlaceGroupTimeSeries[];
   paletteMode: PaletteMode;
   chartType: TimeSeriesChartType;
+  stdevBars: boolean;
 }
 
 export default function TimeSeriesLine({
   timeSeriesGroup,
   timeSeriesIndex,
-  showErrorBars,
   selectTimeSeries,
   places,
   selectPlace,
@@ -68,6 +67,7 @@ export default function TimeSeriesLine({
   placeGroupTimeSeries,
   paletteMode,
   chartType,
+  stdevBars,
 }: TimeSeriesLineProps) {
   // WARNING: we cannot use hooks here, as this is not a normal component!
   // See usage in TimeSeriesChart component.
@@ -138,17 +138,15 @@ export default function TimeSeriesLine({
     };
   }
 
-  const errorBar = source.valueDataKey &&
-    showErrorBars &&
-    source.errorDataKey && (
-      <ErrorBar
-        dataKey={`ev${timeSeriesIndex}`}
-        width={4}
-        strokeWidth={1}
-        stroke={shadedLineColor}
-        strokeOpacity={0.5}
-      />
-    );
+  const errorBar = stdevBars && source.valueDataKey && source.errorDataKey && (
+    <ErrorBar
+      dataKey={`ev${timeSeriesIndex}`}
+      width={4}
+      strokeWidth={1}
+      stroke={shadedLineColor}
+      strokeOpacity={0.5}
+    />
+  );
 
   return chartType === "bar" ? (
     <Bar

--- a/src/connected/TimeSeriesCharts.tsx
+++ b/src/connected/TimeSeriesCharts.tsx
@@ -51,7 +51,7 @@ const mapStateToProps = (state: AppState) => {
     selectedTimeRange: state.controlState.selectedTimeRange,
     dataTimeRange: selectedDatasetTimeRangeSelector(state),
     chartTypeDefault: state.controlState.timeSeriesChartTypeDefault,
-    showErrorBars: state.controlState.showTimeSeriesErrorBars,
+    includeStdev: state.controlState.timeSeriesIncludeStdev,
     placeInfos: timeSeriesPlaceInfosSelector(state),
     places: selectedPlaceGroupPlacesSelector(state),
     placeGroupTimeSeries: placeGroupTimeSeriesSelector(state),

--- a/src/connected/TimeSeriesCharts.tsx
+++ b/src/connected/TimeSeriesCharts.tsx
@@ -50,7 +50,7 @@ const mapStateToProps = (state: AppState) => {
     selectedTime: state.controlState.selectedTime,
     selectedTimeRange: state.controlState.selectedTimeRange,
     dataTimeRange: selectedDatasetTimeRangeSelector(state),
-    showPointsOnly: state.controlState.showTimeSeriesPointsOnly,
+    chartTypeDefault: state.controlState.timeSeriesChartTypeDefault,
     showErrorBars: state.controlState.showTimeSeriesErrorBars,
     placeInfos: timeSeriesPlaceInfosSelector(state),
     places: selectedPlaceGroupPlacesSelector(state),

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -216,19 +216,19 @@
       "se": "Spelarens tidsintervall"
     },
     {
-      "en": "Show graph after adding a place",
-      "de": "Graph anzeigen, nachdem ein Ort hinzugefügt wurde",
+      "en": "Show chart after adding a place",
+      "de": "Diagram anzeigen, nachdem ein Ort hinzugefügt wurde",
       "se": "Visa diagram efter att du har lagt till en plats"
     },
     {
-      "en": "Show error bars",
-      "de": "Fehlerbalken anzeigen",
-      "se": "Visa felstaplar"
+      "en": "Calculate standard deviation",
+      "de": "Berechne Standardabweichung",
+      "se": "Beräkna standardavvikelsen"
     },
     {
-      "en": "Show median instead of mean (disables error bars)",
-      "de": "Median statt Mittelwert anzeigen (deaktiviert Fehlerbalken)",
-      "se": "Visa median i stället för medelvärde (inaktiverar felfält)"
+      "en": "Calculate median instead of mean (disables standard deviation)",
+      "de": "Median statt Mittelwert berechnen (deaktiviert Standardabweichung)",
+      "se": "Beräkna median istället för medelvärde (inaktiverar standardavvikelse)"
     },
     {
       "en": "Minimal number of data points in a time series update",

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -221,11 +221,6 @@
       "se": "Visa diagram efter att du har lagt till en plats"
     },
     {
-      "en": "Show dots only, hide lines",
-      "de": "Nur Punkte anzeigen, Linien ausblenden",
-      "se": "Visa bara punkter, dölj linjer"
-    },
-    {
       "en": "Show error bars",
       "de": "Fehlerbalken anzeigen",
       "se": "Visa felstaplar"

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -63,6 +63,7 @@ export interface InfoCardElementStates {
 }
 
 export type LocateMode = "doNothing" | "pan" | "panAndZoom";
+export type TimeSeriesChartType = "point" | "line" | "bar";
 
 export type UserPlacesFormatName = "geojson" | "csv" | "wkt";
 
@@ -112,7 +113,7 @@ export interface ControlState {
   timeAnimationInterval: TimeAnimationInterval;
   timeChunkSize: number;
   autoShowTimeSeries: boolean;
-  showTimeSeriesPointsOnly: boolean;
+  timeSeriesChartTypeDefault: TimeSeriesChartType;
   showTimeSeriesErrorBars: boolean;
   showTimeSeriesMedian: boolean;
   userDrawnPlaceGroupName: string;
@@ -168,7 +169,7 @@ export function newControlState(): ControlState {
     timeAnimationInterval: 1000,
     timeChunkSize: 20,
     autoShowTimeSeries: true,
-    showTimeSeriesPointsOnly: false,
+    timeSeriesChartTypeDefault: "line",
     showTimeSeriesErrorBars: true,
     showTimeSeriesMedian: branding.defaultAgg === "median",
     userDrawnPlaceGroupName: "",

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -114,8 +114,8 @@ export interface ControlState {
   timeChunkSize: number;
   autoShowTimeSeries: boolean;
   timeSeriesChartTypeDefault: TimeSeriesChartType;
-  showTimeSeriesErrorBars: boolean;
-  showTimeSeriesMedian: boolean;
+  timeSeriesIncludeStdev: boolean;
+  timeSeriesUseMedian: boolean;
   userDrawnPlaceGroupName: string;
   userPlacesFormatName: UserPlacesFormatName;
   userPlacesFormatOptions: UserPlacesFormatOptions;
@@ -170,8 +170,8 @@ export function newControlState(): ControlState {
     timeChunkSize: 20,
     autoShowTimeSeries: true,
     timeSeriesChartTypeDefault: "line",
-    showTimeSeriesErrorBars: true,
-    showTimeSeriesMedian: branding.defaultAgg === "median",
+    timeSeriesIncludeStdev: true,
+    timeSeriesUseMedian: branding.defaultAgg === "median",
     userDrawnPlaceGroupName: "",
     userPlacesFormatName: "csv",
     userPlacesFormatOptions: {

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -58,7 +58,7 @@ export function storeUserSettings(settings: ControlState) {
       storage.setPrimitiveProperty("privacyNoticeAccepted", settings);
       storage.setPrimitiveProperty("autoShowTimeSeries", settings);
       storage.setPrimitiveProperty("showTimeSeriesErrorBars", settings);
-      storage.setPrimitiveProperty("showTimeSeriesPointsOnly", settings);
+      storage.setPrimitiveProperty("timeSeriesChartTypeDefault", settings);
       storage.setPrimitiveProperty("showTimeSeriesMedian", settings);
       storage.setPrimitiveProperty("timeAnimationInterval", settings);
       storage.setPrimitiveProperty("timeChunkSize", settings);
@@ -114,8 +114,8 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
         settings,
         defaultSettings,
       );
-      storage.getBooleanProperty(
-        "showTimeSeriesPointsOnly",
+      storage.getStringProperty(
+        "timeSeriesChartTypeDefault",
         settings,
         defaultSettings,
       );

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -57,9 +57,9 @@ export function storeUserSettings(settings: ControlState) {
       storage.setPrimitiveProperty("locale", settings);
       storage.setPrimitiveProperty("privacyNoticeAccepted", settings);
       storage.setPrimitiveProperty("autoShowTimeSeries", settings);
-      storage.setPrimitiveProperty("showTimeSeriesErrorBars", settings);
+      storage.setPrimitiveProperty("timeSeriesIncludeStdev", settings);
       storage.setPrimitiveProperty("timeSeriesChartTypeDefault", settings);
-      storage.setPrimitiveProperty("showTimeSeriesMedian", settings);
+      storage.setPrimitiveProperty("timeSeriesUseMedian", settings);
       storage.setPrimitiveProperty("timeAnimationInterval", settings);
       storage.setPrimitiveProperty("timeChunkSize", settings);
       storage.setPrimitiveProperty("volumeCardOpen", settings);
@@ -110,7 +110,7 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
         defaultSettings,
       );
       storage.getBooleanProperty(
-        "showTimeSeriesErrorBars",
+        "timeSeriesIncludeStdev",
         settings,
         defaultSettings,
       );
@@ -120,7 +120,7 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
         defaultSettings,
       );
       storage.getBooleanProperty(
-        "showTimeSeriesMedian",
+        "timeSeriesUseMedian",
         settings,
         defaultSettings,
       );


### PR DESCRIPTION
Users can now change the chart type (point, line, bars) and toggle showing standard deviation directly from the time-series chart's action bar.

![image](https://github.com/xcube-dev/xcube-viewer/assets/206773/0c681b79-5029-4743-b3e7-233b405809c8)
