### PR TITLE
Revise new color bar features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@
   band-math expressions. The variables are defined for a given
   dataset and are persisted in the browser's local storage. (#371)
 
+* Revised map color mapping for simplicity and clarity:
+  - Removed the color mapping normalisation modes. Instead introduced
+    a "Log" switch in the value-range popup. The normalisation mode
+    "CAT" (categorical) is no longer required.
+  - Renamed the user color mapping types "Node", "Bound", "Key" into
+    "Cont." (continuous), "Stepwise", and "Categ." (categorical).
+  - The color legend is now showing the variable's UI title instead of the
+    variable identifier name.
+
 * Made the right sidebar panel's tab bar position sticky. (#373)
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,15 @@
 
 * Revised map color mapping for simplicity and clarity. (#390)
   This comprises the following changes:
-  - Removed the color mapping normalisation modes. Instead introduced
+  - Removed the color mapping normalisation modes. Instead, introduced
     a "Log" switch in the value-range popup. The normalisation mode
     "CAT" (categorical) is no longer required.
   - Renamed the user color mapping types "Node", "Bound", "Key" into
     "Cont." (continuous), "Stepwise", and "Categ." (categorical).
   - The color legend is now showing the variable's UI title instead of the
     variable identifier name. 
+  - The value range can now be assigned from the value range
+    of the color mapping values.
 
 * The datasets in the dataset selector are now sorted by name and may
   also be grouped if configured so in xcube server. (#385)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,15 @@
   band-math expressions. The variables are defined for a given
   dataset and are persisted in the browser's local storage. (#371)
 
-* Revised map color mapping for simplicity and clarity:
+* Revised map color mapping for simplicity and clarity. (#390)
+  This comprises the following changes:
   - Removed the color mapping normalisation modes. Instead introduced
     a "Log" switch in the value-range popup. The normalisation mode
     "CAT" (categorical) is no longer required.
   - Renamed the user color mapping types "Node", "Bound", "Key" into
     "Cont." (continuous), "Stepwise", and "Categ." (categorical).
   - The color legend is now showing the variable's UI title instead of the
-    variable identifier name.
+    variable identifier name. 
 
 * Made the right sidebar panel's tab bar position sticky. (#373)
 

--- a/src/components/ColorBarLegend/ColorBarLabels.tsx
+++ b/src/components/ColorBarLegend/ColorBarLabels.tsx
@@ -23,9 +23,9 @@
  */
 
 import React, { useMemo } from "react";
+import Box from "@mui/material/Box";
 
 import { getLabelsForRange } from "@/util/label";
-import Box from "@mui/material/Box";
 import { makeStyles } from "@/util/styles";
 
 const styles = makeStyles({

--- a/src/components/ColorBarLegend/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegend.tsx
@@ -106,12 +106,12 @@ export default function ColorBarLegend(
 
   return (
     <Box sx={styles.container} ref={colorBarSelectAnchorRef}>
-      <Box sx={styles.title}>
-        <span>{variableTitleWithUnits}</span>
+      <Box sx={styles.title} component="span">
+        {variableTitleWithUnits}
       </Box>
       {variableColorBar.type === "key" ? (
         <ColorBarLegendCategorical
-          categories={variableColorBar.colorRecords!}
+          categories={variableColorBar.colorRecords}
           onOpenColorBarEditor={handleOpenColorBarSelect}
           {...props}
         />

--- a/src/components/ColorBarLegend/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegend.tsx
@@ -31,7 +31,7 @@ import { ColorBar, ColorBars } from "@/model/colorBar";
 import { UserColorBar } from "@/model/userColorBar";
 import { ColorBarNorm } from "@/model/variable";
 import ColorBarLegendCategorical from "./ColorBarLegendCategorical";
-import ColorBarLegendContinuous from "./ColorBarLegendContinuous";
+import ColorBarLegendScalable from "./ColorBarLegendScalable";
 import ColorBarColorEditor from "./ColorBarColorEditor";
 
 const styles = makeStyles({
@@ -109,14 +109,14 @@ export default function ColorBarLegend(
       <Box sx={styles.title}>
         <span>{variableTitleWithUnits}</span>
       </Box>
-      {variableColorBar.type === "key" && variableColorBar.categories ? (
+      {variableColorBar.type === "key" ? (
         <ColorBarLegendCategorical
-          variableColorBarCategories={variableColorBar.categories}
+          categories={variableColorBar.colorRecords!}
           onOpenColorBarEditor={handleOpenColorBarSelect}
           {...props}
         />
       ) : (
-        <ColorBarLegendContinuous
+        <ColorBarLegendScalable
           onOpenColorBarEditor={handleOpenColorBarSelect}
           {...props}
         />

--- a/src/components/ColorBarLegend/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegend.tsx
@@ -26,13 +26,13 @@ import { MouseEvent, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 import Popover from "@mui/material/Popover";
 
+import { makeStyles } from "@/util/styles";
 import { ColorBar, ColorBars } from "@/model/colorBar";
 import { UserColorBar } from "@/model/userColorBar";
 import { ColorBarNorm } from "@/model/variable";
 import ColorBarLegendCategorical from "./ColorBarLegendCategorical";
 import ColorBarLegendContinuous from "./ColorBarLegendContinuous";
 import ColorBarColorEditor from "./ColorBarColorEditor";
-import { makeStyles } from "@/util/styles";
 
 const styles = makeStyles({
   container: (theme) => ({
@@ -55,6 +55,7 @@ const styles = makeStyles({
 
 interface ColorBarLegendProps {
   variableName: string | null;
+  variableTitle: string | null;
   variableUnits: string;
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
@@ -79,12 +80,8 @@ interface ColorBarLegendProps {
 export default function ColorBarLegend(
   props: Omit<ColorBarLegendProps, "onOpenColorBarEditor">,
 ) {
-  const {
-    variableName,
-    variableUnits,
-    variableColorBar,
-    variableColorBarNorm,
-  } = props;
+  const { variableName, variableTitle, variableUnits, variableColorBar } =
+    props;
 
   const colorBarSelectAnchorRef = useRef<HTMLDivElement | null>(null);
   const [colorBarSelectAnchorEl, setColorBarSelectAnchorEl] =
@@ -102,16 +99,17 @@ export default function ColorBarLegend(
     return null;
   }
 
-  const variableTitle = variableColorBar.categories
-    ? variableName
-    : `${variableName} (${variableUnits || "-"})`;
+  const variableTitleWithUnits =
+    variableColorBar.type === "key"
+      ? variableTitle || variableName
+      : `${variableTitle || variableName} (${variableUnits || "-"})`;
 
   return (
     <Box sx={styles.container} ref={colorBarSelectAnchorRef}>
       <Box sx={styles.title}>
-        <span>{variableTitle}</span>
+        <span>{variableTitleWithUnits}</span>
       </Box>
-      {variableColorBarNorm === "cat" && variableColorBar.categories ? (
+      {variableColorBar.type === "key" && variableColorBar.categories ? (
         <ColorBarLegendCategorical
           variableColorBarCategories={variableColorBar.categories}
           onOpenColorBarEditor={handleOpenColorBarSelect}
@@ -119,7 +117,6 @@ export default function ColorBarLegend(
         />
       ) : (
         <ColorBarLegendContinuous
-          variableTitle={variableName}
           onOpenColorBarEditor={handleOpenColorBarSelect}
           {...props}
         />

--- a/src/components/ColorBarLegend/ColorBarLegendCategorical.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegendCategorical.tsx
@@ -51,7 +51,7 @@ const styles = makeStyles({
 });
 
 export interface ColorBarLegendCategoricalProps {
-  categories: HexColorRecord[];
+  categories?: HexColorRecord[];
   onOpenColorBarEditor: () => void;
 }
 
@@ -59,6 +59,9 @@ export default function ColorBarLegendCategorical({
   categories,
   onOpenColorBarEditor,
 }: ColorBarLegendCategoricalProps) {
+  if (!categories || categories.length === 0) {
+    return null;
+  }
   return (
     <Box sx={styles.container}>
       {categories.map((category, index) => (

--- a/src/components/ColorBarLegend/ColorBarLegendCategorical.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegendCategorical.tsx
@@ -51,17 +51,17 @@ const styles = makeStyles({
 });
 
 export interface ColorBarLegendCategoricalProps {
-  variableColorBarCategories: HexColorRecord[];
+  categories: HexColorRecord[];
   onOpenColorBarEditor: () => void;
 }
 
 export default function ColorBarLegendCategorical({
-  variableColorBarCategories,
+  categories,
   onOpenColorBarEditor,
 }: ColorBarLegendCategoricalProps) {
   return (
     <Box sx={styles.container}>
-      {variableColorBarCategories.map((category, index) => (
+      {categories.map((category, index) => (
         <Box
           key={index}
           onClick={onOpenColorBarEditor}

--- a/src/components/ColorBarLegend/ColorBarLegendContinuous.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegendContinuous.tsx
@@ -32,7 +32,6 @@ import { ColorBar } from "@/model/colorBar";
 import { ColorBarNorm } from "@/model/variable";
 
 export interface ColorBarLegendContinuousProps {
-  variableTitle: string;
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
   variableColorBarNorm: ColorBarNorm;
@@ -48,7 +47,6 @@ export interface ColorBarLegendContinuousProps {
 }
 
 export default function ColorBarLegendContinuous({
-  variableTitle,
   variableColorBarName,
   variableColorBarMinMax,
   variableColorBarNorm,
@@ -90,7 +88,6 @@ export default function ColorBarLegendContinuous({
         transformOrigin={{ vertical: "top", horizontal: "center" }}
       >
         <ColorBarRangeEditor
-          variableTitle={variableTitle}
           variableColorBarName={variableColorBarName}
           variableColorBarMinMax={variableColorBarMinMax}
           variableColorBarNorm={variableColorBarNorm}

--- a/src/components/ColorBarLegend/ColorBarLegendScalable.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegendScalable.tsx
@@ -25,16 +25,16 @@
 import { MouseEvent, useState } from "react";
 import Popover from "@mui/material/Popover";
 
-import ColorBarCanvas from "./ColorBarCanvas";
-import ColorBarRangeEditor from "./ColorBarRangeEditor";
-import ColorBarLabels from "./ColorBarLabels";
 import { ColorBar } from "@/model/colorBar";
 import { ColorBarNorm } from "@/model/variable";
+import ColorBarCanvas from "./ColorBarCanvas";
+import ColorBarLabels from "./ColorBarLabels";
+import ColorBarRangeEditor from "./ColorBarRangeEditor";
 
-export interface ColorBarLegendContinuousProps {
+export interface ColorBarLegendScalableProps {
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
-  variableColorBarNorm: ColorBarNorm;
+  variableColorBarNorm: ColorBarNorm; // will be "lin" or "log"
   variableColorBar: ColorBar;
   variableOpacity: number;
   updateVariableColorBar: (
@@ -46,7 +46,7 @@ export interface ColorBarLegendContinuousProps {
   onOpenColorBarEditor: () => void;
 }
 
-export default function ColorBarLegendContinuous({
+export default function ColorBarLegendScalable({
   variableColorBarName,
   variableColorBarMinMax,
   variableColorBarNorm,
@@ -54,7 +54,7 @@ export default function ColorBarLegendContinuous({
   variableOpacity,
   updateVariableColorBar,
   onOpenColorBarEditor,
-}: ColorBarLegendContinuousProps) {
+}: ColorBarLegendScalableProps) {
   const [colorBarRangeEditorAnchorEl, setColorBarRangeEditorAnchorEl] =
     useState<HTMLDivElement | null>(null);
 

--- a/src/components/ColorBarLegend/ColorBarLegendScalable.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegendScalable.tsx
@@ -32,10 +32,10 @@ import ColorBarLabels from "./ColorBarLabels";
 import ColorBarRangeEditor from "./ColorBarRangeEditor";
 
 export interface ColorBarLegendScalableProps {
+  variableColorBar: ColorBar;
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
   variableColorBarNorm: ColorBarNorm; // will be "lin" or "log"
-  variableColorBar: ColorBar;
   variableOpacity: number;
   updateVariableColorBar: (
     colorBarName: string,
@@ -47,10 +47,10 @@ export interface ColorBarLegendScalableProps {
 }
 
 export default function ColorBarLegendScalable({
+  variableColorBar,
   variableColorBarName,
   variableColorBarMinMax,
   variableColorBarNorm,
-  variableColorBar,
   variableOpacity,
   updateVariableColorBar,
   onOpenColorBarEditor,
@@ -88,6 +88,7 @@ export default function ColorBarLegendScalable({
         transformOrigin={{ vertical: "top", horizontal: "center" }}
       >
         <ColorBarRangeEditor
+          variableColorBar={variableColorBar}
           variableColorBarName={variableColorBarName}
           variableColorBarMinMax={variableColorBarMinMax}
           variableColorBarNorm={variableColorBarNorm}

--- a/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
@@ -22,13 +22,18 @@
  * SOFTWARE.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Switch from "@mui/material/Switch";
 
+import i18n from "@/i18n";
 import { ColorBarNorm } from "@/model/variable";
-import ColorBarRangeSlider from "./ColorBarRangeSlider";
 import { makeStyles } from "@/util/styles";
+import ColorBarRangeSlider from "./ColorBarRangeSlider";
+import { FormControlLabel } from "@mui/material";
+import Tooltip from "@mui/material/Tooltip";
 
 const HOR_SLIDER_MARGIN = 5;
 
@@ -37,6 +42,10 @@ const styles = makeStyles({
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
   }),
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
   sliderBox: (theme) => ({
     marginTop: theme.spacing(1),
     marginLeft: theme.spacing(HOR_SLIDER_MARGIN),
@@ -59,7 +68,6 @@ const styles = makeStyles({
 });
 
 interface ColorBarRangeEditorProps {
-  variableTitle: string;
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
   variableColorBarNorm: ColorBarNorm;
@@ -73,7 +81,6 @@ interface ColorBarRangeEditorProps {
 }
 
 export default function ColorBarRangeEditor({
-  variableTitle,
   variableColorBarName,
   variableColorBarMinMax,
   variableColorBarNorm,
@@ -147,9 +154,40 @@ export default function ColorBarRangeEditor({
     setEnteredMinMaxError([enteredMinMaxError[0], error]);
   };
 
+  const handleColorBarNorm = (
+    _event: ChangeEvent<HTMLInputElement>,
+    value: boolean,
+  ) => {
+    updateVariableColorBar(
+      variableColorBarName,
+      variableColorBarMinMax,
+      value ? "log" : "lin",
+      variableOpacity,
+    );
+  };
+
   return (
     <Box sx={styles.colorBarMinMaxEditor}>
-      <span style={{ paddingLeft: 14 }}>{variableTitle}</span>
+      <Box sx={styles.header}>
+        <Typography style={{ paddingLeft: 14, fontWeight: "bold" }}>
+          {i18n.get("Scale value-range")}
+        </Typography>
+        <span style={{ flexGrow: 1 }} />
+        <FormControlLabel
+          sx={{ margin: 0 }}
+          control={
+            <Tooltip title={i18n.get("Logarithmic scaling")}>
+              <Switch
+                value={variableColorBarNorm === "log"}
+                onChange={handleColorBarNorm}
+                size="small"
+              />
+            </Tooltip>
+          }
+          label={i18n.get("Log")}
+          labelPlacement="start"
+        />
+      </Box>
       <Box sx={styles.sliderBox}>
         <ColorBarRangeSlider
           variableColorBarName={variableColorBarName}

--- a/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
@@ -29,11 +29,14 @@ import Switch from "@mui/material/Switch";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import CompressIcon from "@mui/icons-material/Compress";
 
 import i18n from "@/i18n";
 import { ColorBarNorm } from "@/model/variable";
 import { makeStyles } from "@/util/styles";
 import ColorBarRangeSlider from "./ColorBarRangeSlider";
+import { ColorBar } from "@/model/colorBar";
+import ToolButton from "@/components/ToolButton";
 
 const HOR_SLIDER_MARGIN = 5;
 
@@ -47,6 +50,7 @@ const styles = makeStyles({
   }),
   header: {
     display: "flex",
+    alignItems: "center",
     justifyContent: "space-between",
   },
   title: { paddingLeft: 2, fontWeight: "bold" },
@@ -73,6 +77,7 @@ const styles = makeStyles({
 });
 
 interface ColorBarRangeEditorProps {
+  variableColorBar: ColorBar;
   variableColorBarName: string;
   variableColorBarMinMax: [number, number];
   variableColorBarNorm: ColorBarNorm;
@@ -86,6 +91,7 @@ interface ColorBarRangeEditorProps {
 }
 
 export default function ColorBarRangeEditor({
+  variableColorBar,
   variableColorBarName,
   variableColorBarMinMax,
   variableColorBarNorm,
@@ -159,6 +165,22 @@ export default function ColorBarRangeEditor({
     setEnteredMinMaxError([enteredMinMaxError[0], error]);
   };
 
+  const handleFromColorRecords = () => {
+    const colorRecords = variableColorBar.colorRecords!;
+    const vMin = colorRecords[0].value;
+    const vMax = colorRecords[colorRecords.length - 1].value;
+    const newMinMax: [number, number] = [vMin, vMax];
+    setCurrentMinMax(newMinMax);
+    setOriginalMinMax(newMinMax);
+    updateVariableColorBar(
+      variableColorBarName,
+      newMinMax,
+      variableColorBarNorm,
+      variableOpacity,
+    );
+    setEnteredMinMaxError([false, false]);
+  };
+
   const handleColorBarNorm = (
     _event: ChangeEvent<HTMLInputElement>,
     value: boolean,
@@ -176,6 +198,14 @@ export default function ColorBarRangeEditor({
       <Box sx={styles.header}>
         <Typography sx={styles.title}>{i18n.get("Value Range")}</Typography>
         <span style={{ flexGrow: 1 }} />
+        {variableColorBar.colorRecords && (
+          <ToolButton
+            sx={{ marginRight: 1 }}
+            icon={<CompressIcon />}
+            onClick={handleFromColorRecords}
+            tooltipText={i18n.get("Set min/max from color mapping values")}
+          />
+        )}
         <FormControlLabel
           sx={styles.logLabel}
           control={

--- a/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorBarRangeEditor.tsx
@@ -23,29 +23,33 @@
  */
 
 import React, { ChangeEvent, useEffect, useState } from "react";
-import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 
 import i18n from "@/i18n";
 import { ColorBarNorm } from "@/model/variable";
 import { makeStyles } from "@/util/styles";
 import ColorBarRangeSlider from "./ColorBarRangeSlider";
-import { FormControlLabel } from "@mui/material";
-import Tooltip from "@mui/material/Tooltip";
 
 const HOR_SLIDER_MARGIN = 5;
 
 const styles = makeStyles({
-  colorBarMinMaxEditor: (theme) => ({
+  container: (theme) => ({
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
   }),
   header: {
     display: "flex",
     justifyContent: "space-between",
   },
+  title: { paddingLeft: 2, fontWeight: "bold" },
   sliderBox: (theme) => ({
     marginTop: theme.spacing(1),
     marginLeft: theme.spacing(HOR_SLIDER_MARGIN),
@@ -53,17 +57,18 @@ const styles = makeStyles({
     minWidth: 320,
     width: `calc(100% - ${theme.spacing(2 * (HOR_SLIDER_MARGIN + 1))}px)`,
   }),
+  logLabel: { margin: 0, paddingRight: 2, fontWeight: "bold" },
   minMaxBox: {
     display: "flex",
     justifyContent: "center",
   },
   minTextField: {
     maxWidth: "8em",
-    paddingRight: 2,
+    marginRight: 2,
   },
   maxTextField: {
     maxWidth: "8em",
-    paddingLeft: 2,
+    marginLeft: 2,
   },
 });
 
@@ -167,24 +172,24 @@ export default function ColorBarRangeEditor({
   };
 
   return (
-    <Box sx={styles.colorBarMinMaxEditor}>
+    <Box sx={styles.container}>
       <Box sx={styles.header}>
-        <Typography style={{ paddingLeft: 14, fontWeight: "bold" }}>
-          {i18n.get("Scale value-range")}
-        </Typography>
+        <Typography sx={styles.title}>{i18n.get("Value Range")}</Typography>
         <span style={{ flexGrow: 1 }} />
         <FormControlLabel
-          sx={{ margin: 0 }}
+          sx={styles.logLabel}
           control={
             <Tooltip title={i18n.get("Logarithmic scaling")}>
               <Switch
-                value={variableColorBarNorm === "log"}
+                checked={variableColorBarNorm === "log"}
                 onChange={handleColorBarNorm}
                 size="small"
               />
             </Tooltip>
           }
-          label={i18n.get("Log")}
+          label={
+            <Typography variant="body2">{i18n.get("Log-scaled")}</Typography>
+          }
           labelPlacement="start"
         />
       </Box>

--- a/src/components/ColorBarLegend/ColorBarStyleEditor.tsx
+++ b/src/components/ColorBarLegend/ColorBarStyleEditor.tsx
@@ -22,11 +22,9 @@
  * SOFTWARE.
  */
 
-import { MouseEvent } from "react";
 import Box from "@mui/material/Box";
 import Slider from "@mui/material/Slider";
 import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Tooltip from "@mui/material/Tooltip";
 import InvertColorsIcon from "@mui/icons-material/InvertColors";
 import OpacityIcon from "@mui/icons-material/Opacity";
@@ -111,18 +109,6 @@ export default function ColorBarStyleEditor({
     );
   };
 
-  const handleColorBarNorm = (
-    _event: MouseEvent<HTMLElement>,
-    value: ColorBarNorm,
-  ) => {
-    updateVariableColorBar(
-      variableColorBarName,
-      variableColorBarMinMax,
-      value,
-      variableOpacity,
-    );
-  };
-
   const handleVariableOpacity = (_event: Event, value: number | number[]) => {
     updateVariableColorBar(
       variableColorBarName,
@@ -157,26 +143,6 @@ export default function ColorBarStyleEditor({
             </ToggleButton>
           </Tooltip>
         </Box>
-        <ToggleButtonGroup
-          exclusive
-          value={variableColorBarNorm}
-          onChange={handleColorBarNorm}
-          size="small"
-        >
-          <ToggleButton value="lin" sx={styles.toggleButton}>
-            <Box fontSize="small">Lin</Box>
-          </ToggleButton>
-          <ToggleButton value="log" sx={styles.toggleButton}>
-            <Box fontSize="small">Log</Box>
-          </ToggleButton>
-          <ToggleButton
-            value="cat"
-            sx={styles.toggleButton}
-            disabled={!variableColorBar.categories}
-          >
-            <Box fontSize="small">Cat</Box>
-          </ToggleButton>
-        </ToggleButtonGroup>
       </Box>
       <Box component="div" sx={styles.opacityContainer}>
         <Box component="span" fontSize="small" sx={styles.opacityLabel}>

--- a/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
@@ -38,12 +38,14 @@ const styles = makeStyles({
   label: { fontSize: "small" },
 });
 
-// TODO: i18n for titles
-// TODO: adjust tooltips
 const typeLabels: [ColorMapType, string, string][] = [
-  ["node", "Contin.", "Values are nodes of a continuous color gradient"],
-  ["bound", "Stepwise", "Values are bounds identifying individual colors"],
-  ["key", "Categ.", "Values are integer keys identifying individual colors"],
+  ["node", "Contin.", "Continuous color mapping where values are nodes"],
+  [
+    "bound",
+    "Stepwise",
+    "Stepwise color mapping where values are bounds of ranges",
+  ],
+  ["key", "Categ.", "Values and their colors represent categories/classes"],
 ];
 
 interface ColorMapTypeEditorProps {

--- a/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
@@ -38,10 +38,12 @@ const styles = makeStyles({
   label: { fontSize: "small" },
 });
 
-const tooltipTitles: [ColorMapType, string][] = [
-  ["node", "Values are nodes of a continuous color gradient"],
-  ["bound", "Values are bounds identifying individual colors"],
-  ["key", "Values are integer keys identifying individual colors"],
+// TODO: i18n for titles
+// TODO: adjust tooltips
+const typeLabels: [ColorMapType, string, string][] = [
+  ["node", "Contin.", "Values are nodes of a continuous color gradient"],
+  ["bound", "Stepwise", "Values are bounds identifying individual colors"],
+  ["key", "Categ.", "Values are integer keys identifying individual colors"],
 ];
 
 interface ColorMapTypeEditorProps {
@@ -62,14 +64,14 @@ export default function ColorMapTypeEditor({
       }}
       sx={styles.radioGroup}
     >
-      {tooltipTitles.map(([type, tooltipTitle]) => (
+      {typeLabels.map(([type, title, tooltipTitle]) => (
         <Tooltip key={type} arrow title={i18n.get(tooltipTitle)}>
           <FormControlLabel
             value={type}
             control={<Radio size="small" sx={styles.radio} />}
             label={
               <Box component="span" sx={styles.label}>
-                {i18n.get(toLabel(type))}
+                {i18n.get(title)}
               </Box>
             }
           />
@@ -77,8 +79,4 @@ export default function ColorMapTypeEditor({
       ))}
     </RadioGroup>
   );
-}
-
-function toLabel(type: string) {
-  return type[0].toUpperCase() + type.substring(1);
 }

--- a/src/components/ToolButton.tsx
+++ b/src/components/ToolButton.tsx
@@ -24,13 +24,14 @@
 
 import * as React from "react";
 import { MouseEvent } from "react";
+import { SxProps } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
+import ToggleButton from "@mui/material/ToggleButton";
 import Tooltip from "@mui/material/Tooltip";
-import { ToggleButton } from "@mui/material";
-
-import { commonStyles } from "./common-styles";
 
 interface ToolButtonProps {
+  sx?: SxProps;
+  className?: string;
   icon: React.ReactElement;
   onClick: (
     event: MouseEvent<HTMLButtonElement | HTMLElement>,
@@ -38,21 +39,21 @@ interface ToolButtonProps {
   ) => void;
   disabled?: boolean;
   tooltipText?: string;
-  className?: string;
   toggle?: boolean;
-  value?: string;
+  value?: string; // required for toggle buttons
   selected?: boolean;
 }
 
 const ToolButton: React.FC<ToolButtonProps> = ({
+  sx,
   className,
   disabled,
   onClick,
   icon,
   tooltipText,
-  toggle = false,
-  value = "",
-  selected = false,
+  toggle,
+  value,
+  selected,
 }) => {
   const handleClick = (event: MouseEvent<HTMLElement>) => {
     if (toggle) {
@@ -73,13 +74,13 @@ const ToolButton: React.FC<ToolButtonProps> = ({
   if (toggle) {
     return (
       <ToggleButton
+        sx={{ padding: 0.3, ...sx }}
         className={className}
         disabled={disabled}
         size="small"
         onClick={handleClick}
-        value={value}
+        value={value || ""}
         selected={selected}
-        sx={commonStyles.toggleButton}
       >
         {iconComp}
       </ToggleButton>
@@ -87,10 +88,11 @@ const ToolButton: React.FC<ToolButtonProps> = ({
   } else {
     return (
       <IconButton
+        sx={sx}
         className={className}
         disabled={disabled}
-        onClick={handleClick}
         size="small"
+        onClick={handleClick}
       >
         {iconComp}
       </IconButton>

--- a/src/connected/ColorBarLegend.tsx
+++ b/src/connected/ColorBarLegend.tsx
@@ -35,6 +35,7 @@ import {
   colorBarsSelector,
   userColorBarsSelector,
   selectedVariableColorBarNormSelector,
+  selectedVariableTitleSelector,
 } from "@/selectors/controlSelectors";
 import { updateVariableColorBar } from "@/actions/dataActions";
 import {
@@ -48,6 +49,7 @@ import _ColorBarLegend from "@/components/ColorBarLegend";
 const mapStateToProps = (state: AppState) => {
   return {
     variableName: selectedVariableNameSelector(state),
+    variableTitle: selectedVariableTitleSelector(state),
     variableUnits: selectedVariableUnitsSelector(state),
     variableColorBarName: selectedVariableColorBarNameSelector(state),
     variableColorBarMinMax: selectedVariableColorBarMinMaxSelector(state),

--- a/src/model/colorBar.ts
+++ b/src/model/colorBar.ts
@@ -83,7 +83,7 @@ export interface ColorBar {
    * Color records. Defined, if this color bar is a
    * custom color bar.
    */
-  categories?: HexColorRecord[];
+  colorRecords?: HexColorRecord[];
 }
 
 export function parseColorBarName(name: string): ColorBar {

--- a/src/model/colorBar.ts
+++ b/src/model/colorBar.ts
@@ -24,6 +24,7 @@
 
 import bgImageData from "./bg.png";
 import { RGBA } from "@/util/color";
+import { ColorMapType } from "@/model/userColorBar";
 
 const BG_IMAGE = new Image();
 BG_IMAGE.src = bgImageData;
@@ -74,8 +75,13 @@ export interface ColorBar {
    */
   imageData?: string;
   /**
-   * Defined, if this color bar is a user-defined categorical color bar,
-   * that its `userColorBar.type` is "bound" or "key".
+   * Color map type. Defined, if this color bar is a
+   * custom color bar
+   */
+  type?: ColorMapType;
+  /**
+   * Color records. Defined, if this color bar is a
+   * custom color bar.
    */
   categories?: HexColorRecord[];
 }

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -24,7 +24,7 @@
 
 import { VolumeRenderMode } from "@/states/controlState";
 
-export type ColorBarNorm = "lin" | "log" | "cat";
+export type ColorBarNorm = "lin" | "log";
 
 export interface Variable {
   id: string;

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -286,6 +286,26 @@
       "se": "Opacitet"
     },
     {
+      "en": "Value Range",
+      "de": "Wertebereich",
+      "se": "Värdeintervall"
+    },
+    {
+      "en": "Log-scaled",
+      "de": "Log-skaliert",
+      "se": "Log-skalad"
+    },
+    {
+      "en": "Logarithmic scaling",
+      "de": "Logarithmische Skalierung",
+      "se": "Logaritmisk skalning"
+    },
+    {
+      "en": "Others",
+      "de": "Andere",
+      "se": "Andra"
+    },
+    {
       "en": "Dataset information",
       "de": "Informationen zum Datensatz",
       "se": "Information om dataset"
@@ -921,34 +941,34 @@
       "se": "Användardefinierade färgskalor."
     },
     {
-      "en": "Node",
-      "de": "Knoten",
-      "se": "Noder"
+      "en": "Contin.",
+      "de": "Kontin.",
+      "se": "Kontin."
     },
     {
-      "en": "Bound",
-      "de": "Grenzen",
-      "se": "Gränser"
+      "en": "Stepwise",
+      "de": "Schrittw.",
+      "se": "Stegvis"
     },
     {
-      "en": "Key",
-      "de": "Schlüssel",
-      "se": "Nycklar"
+      "en": "Categ.",
+      "de": "Kateg.",
+      "se": "Kateg."
     },
     {
-      "en": "Values are nodes of a continuous color gradient",
-      "de": "Werte sind Knoten eines kontinuierlichen Farbverlaufs",
-      "se": "Värden är noder i en kontinuerlig färggradient"
+      "en": "Continuous color mapping where values are nodes",
+      "de": "Kontinuierliche Farbzuordnung, bei der Werte Knoten sind",
+      "se": "Kontinuerlig färgkartläggning där värden är noder"
     },
     {
-      "en": "Values are bounds identifying individual colors",
-      "de": "Werte sind Grenzen, die einzelne Farben identifizieren",
-      "se": "Värden är gränser som identifierar enskilda färger"
+      "en": "Stepwise color mapping where values are bounds of ranges",
+      "de": "Schrittweise Farbzuordnung, bei der die Werte Bereichsgrenzen darstellen",
+      "se": "Stegvis färgmappning där värden är gränser för intervall"
     },
     {
-      "en": "Values are integer keys identifying individual colors",
-      "de": "Werte sind ganzzahlige Schlüssel, die einzelne Farben identifizieren",
-      "se": "Värden är heltalsnycklar som identifierar enskilda färger"
+      "en": "Values and their colors represent categories/classes",
+      "de": "Werte und deren Farben repräsentieren Kategorien/Klassen",
+      "se": "Värden och deras färger representerar kategorier/klasser"
     },
     {
       "en": "User",

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -291,6 +291,11 @@
       "se": "Värdeintervall"
     },
     {
+      "en": "Assign min/max from color mapping values",
+      "de": "Min./Max. aus Farbzuordnungswerten übertragen",
+      "se": "Tilldela min/max från färgmappningsvärden"
+    },
+    {
       "en": "Log-scaled",
       "de": "Log-skaliert",
       "se": "Log-skalad"

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -88,7 +88,6 @@ import {
   ColorBar,
   ColorBarGroup,
   ColorBars,
-  HexColorRecord,
   parseColorBarName,
 } from "@/model/colorBar";
 import {

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -329,8 +329,8 @@ const getVariableColorBar = (
   );
   if (userColorBar) {
     const type = userColorBar.type;
-    const categories = getUserColorBarHexRecords(userColorBar.code);
-    return { ...colorBar, imageData, type, categories };
+    const colorRecords = getUserColorBarHexRecords(userColorBar.code);
+    return { ...colorBar, imageData, type, colorRecords };
   }
   return { ...colorBar, imageData };
 };


### PR DESCRIPTION
Revised map color mapping for simplicity and clarity:

- Removed the color mapping normalisation modes. Instead introduced a "Log" switch in the value-range popup. The normalisation mode "CAT" (categorical) is no longer required.
- Renamed the user color mapping types "Node", "Bound", "Key" into "Cont." (continuous), "Stepwise", and "Categ." (categorical).
- The color legend is now showing the variable's UI title instead of the variable identifier name.

Requires https://github.com/xcube-dev/xcube/pull/1044

Closes #390

To verify use the demo server setup, then in the UI

- create three new color bars: continuous, stepwise, categorical each with 3 values: 0, 1, 2
- apply each to conc_chl and watch the colors in the map chaning 
- apply each to chl_category and watch the legend changing if the categorical colorbar is selected
- check the legend is changing to a list if the categorical colorbar is selected
- for continuous, stepwise color bars check linear/log scaling in the value range editor 
