### PR TITLE
Change color and opacity of user places

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 * Made the right sidebar panel's tab bar position sticky. (#373)
 
+* It is now possible to change the color and opacity of user places
+  and hence associated timeseries and statistic charts. (#216, #97)
+
 ### Fixes
 
 * Fixed a problem that caused categorical map legends to list the categories

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 * It is now possible to change the color and opacity of user places
   and hence associated timeseries and statistic charts. (#216, #97)
 
+* Improved visual style of selected places in the map.
+
 ### Fixes
 
 * Fixed a problem that caused categorical map legends to list the categories

--- a/src/actions/mapActions.tsx
+++ b/src/actions/mapActions.tsx
@@ -24,6 +24,8 @@
 
 import { default as OlMap } from "ol/Map";
 import { Geometry as OlGeometry } from "ol/geom";
+import { Vector as OlVectorLayer } from "ol/layer";
+import { Vector as OlVectorSource } from "ol/source";
 import { fromExtent } from "ol/geom/Polygon";
 import { Extent as OlExtent } from "ol/extent";
 import { getCenter } from "ol/extent";
@@ -31,6 +33,8 @@ import { default as OlSimpleGeometry } from "ol/geom/SimpleGeometry";
 
 import { GEOGRAPHIC_CRS } from "@/model/proj";
 import { MAP_OBJECTS } from "@/states/controlState";
+import { PlaceStyle } from "@/model/place";
+import { setFeatureStyle } from "@/components/ol/style";
 
 // noinspection JSUnusedLocalSymbols
 export function renameUserPlaceInLayer(
@@ -44,6 +48,24 @@ export function renameUserPlaceInLayer(
     // TODO (forman): update feature source in user layer to reflect newName.
     //  Note, this is not yet an issue, because we still don't show user places labels
     //  in the viewer.
+  }
+}
+
+export function restyleUserPlaceInLayer(
+  placeGroupId: string,
+  placeId: string,
+  placeStyle: PlaceStyle,
+) {
+  if (MAP_OBJECTS[placeGroupId]) {
+    const userLayer = MAP_OBJECTS[
+      placeGroupId
+    ] as OlVectorLayer<OlVectorSource>;
+    const source = userLayer.getSource();
+    const feature = source?.getFeatureById(placeId);
+    if (feature) {
+      // console.log("selected feature:", feature, placeStyle);
+      setFeatureStyle(feature, placeStyle.color, placeStyle.opacity);
+    }
   }
 }
 

--- a/src/components/PlaceSelect.tsx
+++ b/src/components/PlaceSelect.tsx
@@ -98,8 +98,6 @@ export default function PlaceSelect({
   selectedPlaceId = selectedPlaceId || "";
   selectedPlaceGroupIds = selectedPlaceGroupIds || [];
 
-  console.log("selectedPlaceInfo:", selectedPlaceInfo);
-
   const selectedPlaceGroupId =
     selectedPlaceGroupIds!.length === 1 ? selectedPlaceGroupIds![0] : null;
 
@@ -146,7 +144,15 @@ export default function PlaceSelect({
     selectedPlaceGroupId.startsWith(USER_ID_PREFIX) &&
     selectedPlaceId !== "";
 
-  let actions;
+  let actions = [
+    <ToolButton
+      key="locatePlace"
+      onClick={locateSelectedPlace}
+      tooltipText={i18n.get("Locate place in map")}
+      icon={<TravelExploreIcon />}
+    />,
+  ];
+
   if (!editMode && isEditableUserPlace) {
     const handleEditButtonClick = () => {
       setEditMode(true);
@@ -179,13 +185,7 @@ export default function PlaceSelect({
         tooltipText={i18n.get("Remove place")}
         icon={<RemoveCircleOutlineIcon />}
       />,
-      <ToolButton
-        key="locatePlace"
-        onClick={locateSelectedPlace}
-        tooltipText={i18n.get("Locate place in map")}
-        icon={<TravelExploreIcon />}
-      />,
-    ];
+    ].concat(actions);
   }
 
   return (
@@ -204,6 +204,7 @@ export default function PlaceSelect({
         <PlaceStyleEditor
           anchorEl={styleAnchorEl}
           setAnchorEl={setStyleAnchorEl}
+          isPoint={selectedPlaceInfo.place.geometry.type === "Point"}
           placeStyle={selectedPlaceInfo}
           updatePlaceStyle={updatePlaceStyle}
         />

--- a/src/components/PlaceSelect.tsx
+++ b/src/components/PlaceSelect.tsx
@@ -22,21 +22,23 @@
  * SOFTWARE.
  */
 
-import * as React from "react";
+import { useState, MouseEvent } from "react";
+import { SxProps } from "@mui/system";
 import Input from "@mui/material/Input";
 import MenuItem from "@mui/material/MenuItem";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
-import { SxProps } from "@mui/system";
 import EditIcon from "@mui/icons-material/Edit";
+import FormatColorFillIcon from "@mui/icons-material/FormatColorFill";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
 import TravelExploreIcon from "@mui/icons-material/TravelExplore";
 
 import i18n from "@/i18n";
 import { Dataset } from "@/model/dataset";
-import { Place, USER_ID_PREFIX } from "@/model/place";
+import { Place, PlaceInfo, PlaceStyle, USER_ID_PREFIX } from "@/model/place";
 import { WithLocale } from "@/util/lang";
 import EditableSelect from "./EditableSelect";
 import ToolButton from "./ToolButton";
+import PlaceStyleEditor from "@/components/PlaceStyleEditor";
 
 // noinspection JSUnusedLocalSymbols
 const styles: Record<string, SxProps> = {
@@ -49,6 +51,7 @@ interface PlaceSelectProps extends WithLocale {
   datasets: Dataset[];
   selectedPlaceGroupIds: string[] | null;
   selectedPlaceId: string | null;
+  selectedPlaceInfo: PlaceInfo | null;
   places: Place[];
   placeLabels: string[];
   selectPlace: (
@@ -60,6 +63,11 @@ interface PlaceSelectProps extends WithLocale {
     placeGroupId: string,
     placeId: string,
     placeName: string,
+  ) => void;
+  restyleUserPlace: (
+    placeGroupId: string,
+    placeId: string,
+    placeStyle: PlaceStyle,
   ) => void;
   removeUserPlace: (
     placeGroupId: string,
@@ -75,17 +83,22 @@ export default function PlaceSelect({
   placeLabels,
   selectedPlaceId,
   selectedPlaceGroupIds,
+  selectedPlaceInfo,
   renameUserPlace,
+  restyleUserPlace,
   removeUserPlace,
   places,
   locateSelectedPlace,
 }: PlaceSelectProps) {
-  const [editMode, setEditMode] = React.useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [styleAnchorEl, setStyleAnchorEl] = useState<HTMLElement | null>(null);
 
   places = places || [];
   placeLabels = placeLabels || [];
   selectedPlaceId = selectedPlaceId || "";
   selectedPlaceGroupIds = selectedPlaceGroupIds || [];
+
+  console.log("selectedPlaceInfo:", selectedPlaceInfo);
 
   const selectedPlaceGroupId =
     selectedPlaceGroupIds!.length === 1 ? selectedPlaceGroupIds![0] : null;
@@ -95,6 +108,10 @@ export default function PlaceSelect({
 
   const setPlaceName = (placeName: string) => {
     renameUserPlace(selectedPlaceGroupId!, selectedPlaceId!, placeName);
+  };
+
+  const updatePlaceStyle = (placeStyle: PlaceStyle) => {
+    restyleUserPlace(selectedPlaceGroupId!, selectedPlaceId!, placeStyle);
   };
 
   const handlePlaceChange = (event: SelectChangeEvent) => {
@@ -135,6 +152,10 @@ export default function PlaceSelect({
       setEditMode(true);
     };
 
+    const handleStyleButtonClick = (event: MouseEvent<HTMLElement>) => {
+      setStyleAnchorEl(event.currentTarget);
+    };
+
     const handleRemoveButtonClick = () => {
       removeUserPlace(selectedPlaceGroupId!, selectedPlaceId!, places);
     };
@@ -145,6 +166,12 @@ export default function PlaceSelect({
         onClick={handleEditButtonClick}
         tooltipText={i18n.get("Rename place")}
         icon={<EditIcon />}
+      />,
+      <ToolButton
+        key="styleButton"
+        onClick={handleStyleButtonClick}
+        tooltipText={i18n.get("Style place")}
+        icon={<FormatColorFillIcon />}
       />,
       <ToolButton
         key="removeButton"
@@ -162,15 +189,25 @@ export default function PlaceSelect({
   }
 
   return (
-    <EditableSelect
-      itemValue={placeName}
-      setItemValue={setPlaceName}
-      validateItemValue={(v) => v.trim().length > 0}
-      editMode={editMode}
-      setEditMode={setEditMode}
-      labelText={i18n.get("Place")}
-      select={select}
-      actions={actions}
-    />
+    <>
+      <EditableSelect
+        itemValue={placeName}
+        setItemValue={setPlaceName}
+        validateItemValue={(v) => v.trim().length > 0}
+        editMode={editMode}
+        setEditMode={setEditMode}
+        labelText={i18n.get("Place")}
+        select={select}
+        actions={actions}
+      />
+      {selectedPlaceInfo && (
+        <PlaceStyleEditor
+          anchorEl={styleAnchorEl}
+          setAnchorEl={setStyleAnchorEl}
+          placeStyle={selectedPlaceInfo}
+          updatePlaceStyle={updatePlaceStyle}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/PlaceStyleEditor/PlaceStyleEditor.tsx
+++ b/src/components/PlaceStyleEditor/PlaceStyleEditor.tsx
@@ -72,9 +72,10 @@ const styles = makeStyles({
   colorMenuItemBox: { width: "104px", height: "18px" },
 });
 
-interface FeatureStyleEditorProps extends WithLocale {
+interface PlaceStyleEditorProps extends WithLocale {
   anchorEl: HTMLElement | null;
   setAnchorEl: (anchorEl: HTMLElement | null) => void;
+  isPoint: boolean;
   placeStyle: PlaceStyle;
   updatePlaceStyle: (placeStyle: PlaceStyle) => void;
 }
@@ -82,9 +83,10 @@ interface FeatureStyleEditorProps extends WithLocale {
 const PlaceStyleEditor = ({
   anchorEl,
   setAnchorEl,
+  isPoint,
   placeStyle,
   updatePlaceStyle,
-}: FeatureStyleEditorProps) => {
+}: PlaceStyleEditorProps) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
 
   function handleColorClick(event: MouseEvent<HTMLDivElement>) {
@@ -102,7 +104,10 @@ const PlaceStyleEditor = ({
       >
         <Box sx={styles.container}>
           <Typography sx={styles.colorLabel}>{i18n.get("Color")}</Typography>
-          <Typography sx={styles.opacityLabel}>
+          <Typography
+            sx={styles.opacityLabel}
+            color={isPoint ? "text.secondary" : "text.primary"}
+          >
             {i18n.get("Opacity")}
           </Typography>
           <Box
@@ -112,6 +117,7 @@ const PlaceStyleEditor = ({
           />
           <Slider
             sx={styles.opacityValue}
+            disabled={isPoint}
             size="small"
             min={0}
             max={1}

--- a/src/components/PlaceStyleEditor/PlaceStyleEditor.tsx
+++ b/src/components/PlaceStyleEditor/PlaceStyleEditor.tsx
@@ -1,0 +1,155 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { WithLocale } from "@/util/lang";
+import { makeStyles } from "@/util/styles";
+import Popover from "@mui/material/Popover";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import i18n from "@/i18n";
+import Slider from "@mui/material/Slider";
+import { PlaceStyle } from "@/model/place";
+import { MouseEvent, useState } from "react";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { userPlaceColorsArray } from "@/config";
+import Tooltip from "@mui/material/Tooltip";
+
+const styles = makeStyles({
+  container: {
+    display: "grid",
+    gridTemplateColumns: "auto 120px",
+    gridTemplateRows: "auto",
+    gridTemplateAreas: "'colorLabel colorValue' 'opacityLabel opacityValue'",
+    rowGap: 1,
+    columnGap: 2.5,
+    padding: 1,
+  },
+  colorLabel: {
+    gridArea: "colorLabel",
+    alignSelf: "center",
+  },
+  colorValue: {
+    gridArea: "colorValue",
+    alignSelf: "center",
+    width: "100%",
+    height: "22px",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "black",
+  },
+  opacityLabel: {
+    gridArea: "opacityLabel",
+    alignSelf: "center",
+  },
+  opacityValue: {
+    gridArea: "opacityValue",
+    alignSelf: "center",
+    width: "100%",
+  },
+  colorMenuItem: { padding: "4px 8px 4px 8px" },
+  colorMenuItemBox: { width: "104px", height: "18px" },
+});
+
+interface FeatureStyleEditorProps extends WithLocale {
+  anchorEl: HTMLElement | null;
+  setAnchorEl: (anchorEl: HTMLElement | null) => void;
+  placeStyle: PlaceStyle;
+  updatePlaceStyle: (placeStyle: PlaceStyle) => void;
+}
+
+const PlaceStyleEditor = ({
+  anchorEl,
+  setAnchorEl,
+  placeStyle,
+  updatePlaceStyle,
+}: FeatureStyleEditorProps) => {
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+
+  function handleColorClick(event: MouseEvent<HTMLDivElement>) {
+    setMenuAnchorEl(event.currentTarget);
+  }
+
+  return (
+    <>
+      <Popover
+        open={anchorEl !== null}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+      >
+        <Box sx={styles.container}>
+          <Typography sx={styles.colorLabel}>{i18n.get("Color")}</Typography>
+          <Typography sx={styles.opacityLabel}>
+            {i18n.get("Opacity")}
+          </Typography>
+          <Box
+            sx={styles.colorValue}
+            style={{ backgroundColor: placeStyle.color }}
+            onClick={handleColorClick}
+          />
+          <Slider
+            sx={styles.opacityValue}
+            size="small"
+            min={0}
+            max={1}
+            step={0.05}
+            value={placeStyle.opacity}
+            onChange={(_, value) =>
+              updatePlaceStyle({ ...placeStyle, opacity: value as number })
+            }
+          />
+        </Box>
+      </Popover>
+      <Menu
+        open={!!menuAnchorEl}
+        anchorEl={menuAnchorEl}
+        onClose={() => setMenuAnchorEl(null)}
+      >
+        {userPlaceColorsArray.map(([colorName, _]) => (
+          <MenuItem
+            key={colorName}
+            selected={placeStyle.color === colorName}
+            sx={styles.colorMenuItem}
+            onClick={() =>
+              updatePlaceStyle({ ...placeStyle, color: colorName })
+            }
+          >
+            <Tooltip title={colorName}>
+              <Box
+                sx={{
+                  ...styles.colorMenuItemBox,
+                  backgroundColor: colorName,
+                }}
+              />
+            </Tooltip>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default PlaceStyleEditor;

--- a/src/components/PlaceStyleEditor/index.tsx
+++ b/src/components/PlaceStyleEditor/index.tsx
@@ -1,0 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import PlaceStyleEditor from "./PlaceStyleEditor";
+
+export default PlaceStyleEditor;

--- a/src/components/UserVectorLayer.tsx
+++ b/src/components/UserVectorLayer.tsx
@@ -30,6 +30,7 @@ import { Config } from "@/config";
 import { PlaceGroup, USER_DRAWN_PLACE_GROUP_ID } from "@/model/place";
 import { Vector } from "./ol/layer/Vector";
 import { setFeatureStyle } from "./ol/style";
+import { isNumber } from "@/util/types";
 
 interface UserVectorLayerProps {
   placeGroup: PlaceGroup;
@@ -69,13 +70,16 @@ const UserVectorLayer: React.FC<UserVectorLayerProps> = ({
           feature.setId(place.id);
         }
         const color = (place.properties || {}).color || "red";
+        const opacity = (place.properties || {}).opacity;
         const pointSymbol = (place.properties || {}).source
           ? "diamond"
           : "circle";
         setFeatureStyle(
           feature,
           color,
-          Config.instance.branding.polygonFillOpacity,
+          isNumber(opacity)
+            ? opacity
+            : Config.instance.branding.polygonFillOpacity,
           pointSymbol,
         );
         source.addFeature(feature);

--- a/src/components/UserVectorLayer.tsx
+++ b/src/components/UserVectorLayer.tsx
@@ -26,11 +26,10 @@ import * as React from "react";
 import { default as OlVectorSource } from "ol/source/Vector";
 import { default as OlGeoJSONFormat } from "ol/format/GeoJSON";
 
-import { Config } from "@/config";
+import { getUserPlaceFillOpacity } from "@/config";
 import { PlaceGroup, USER_DRAWN_PLACE_GROUP_ID } from "@/model/place";
 import { Vector } from "./ol/layer/Vector";
 import { setFeatureStyle } from "./ol/style";
-import { isNumber } from "@/util/types";
 
 interface UserVectorLayerProps {
   placeGroup: PlaceGroup;
@@ -77,9 +76,7 @@ const UserVectorLayer: React.FC<UserVectorLayerProps> = ({
         setFeatureStyle(
           feature,
           color,
-          isNumber(opacity)
-            ? opacity
-            : Config.instance.branding.polygonFillOpacity,
+          getUserPlaceFillOpacity(opacity),
           pointSymbol,
         );
         source.addFeature(feature);
@@ -92,7 +89,7 @@ const UserVectorLayer: React.FC<UserVectorLayerProps> = ({
       id={placeGroup.id}
       opacity={placeGroup.id === USER_DRAWN_PLACE_GROUP_ID ? 1 : 0.8}
       visible={visible}
-      zIndex={500}
+      zIndex={501}
       source={sourceRef.current}
     />
   );

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -42,7 +42,11 @@ import { default as OlStyle } from "ol/style/Style";
 import { getRenderPixel } from "ol/render";
 
 import i18n from "@/i18n";
-import { Config, getUserPlaceColor, getUserPlaceColorName } from "@/config";
+import {
+  getUserPlaceColor,
+  getUserPlaceColorName,
+  getUserPlaceFillOpacity,
+} from "@/config";
 import {
   Place,
   PlaceGroup,
@@ -78,19 +82,30 @@ const COLOR_LEGEND_STYLE: React.CSSProperties = {
   top: 10,
 };
 
+const SELECTION_COLOR = [255, 220, 0, 0.8];
+
 const SELECTION_LAYER_STROKE = new OlStrokeStyle({
-  color: [255, 200, 0, 1.0],
-  width: 3,
+  color: SELECTION_COLOR,
+  width: 10,
+  lineCap: "square",
+  lineDash: [10, 15],
 });
+
 const SELECTION_LAYER_FILL = new OlFillStyle({
-  color: [255, 200, 0, 0.05],
+  color: [0, 0, 0, 0],
 });
+
 const SELECTION_LAYER_STYLE = new OlStyle({
   stroke: SELECTION_LAYER_STROKE,
   fill: SELECTION_LAYER_FILL,
   image: new OlCircleStyle({
-    radius: 10,
-    stroke: SELECTION_LAYER_STROKE,
+    radius: 15,
+    stroke: new OlStrokeStyle({
+      color: SELECTION_COLOR,
+      width: 6,
+      lineCap: "square",
+      lineDash: [6, 6],
+    }),
     fill: SELECTION_LAYER_FILL,
   }),
 });
@@ -320,11 +335,7 @@ export default function Viewer({
       const label = findNextLabel(userPlaceGroups, mapInteraction);
       const color = getUserPlaceColorName(colorIndex);
       const shadedColor = getUserPlaceColor(color, theme.palette.mode);
-      setFeatureStyle(
-        feature,
-        shadedColor,
-        Config.instance.branding.polygonFillOpacity,
-      );
+      setFeatureStyle(feature, shadedColor, getUserPlaceFillOpacity());
 
       addDrawnUserPlace(
         userDrawnPlaceGroupName,
@@ -386,6 +397,13 @@ export default function Viewer({
           {variableLayer}
           {overlayLayer}
           {datasetBoundaryLayer}
+          <Vector
+            id={SELECTION_LAYER_ID}
+            opacity={0.7}
+            zIndex={500}
+            style={SELECTION_LAYER_STYLE}
+            source={SELECTION_LAYER_SOURCE}
+          />
           {
             <>
               {userPlaceGroups.map((placeGroup) => (
@@ -400,13 +418,6 @@ export default function Viewer({
               ))}
             </>
           }
-          <Vector
-            id={SELECTION_LAYER_ID}
-            opacity={0.7}
-            zIndex={510}
-            style={SELECTION_LAYER_STYLE}
-            source={SELECTION_LAYER_SOURCE}
-          />
         </Layers>
         {placeGroupLayers}
         {/*<Select id='select' selectedFeaturesIds={selectedFeaturesId} onSelect={handleSelect}/>*/}

--- a/src/components/ol/style.ts
+++ b/src/components/ol/style.ts
@@ -43,7 +43,7 @@ export function setFeatureStyle(
 ) {
   if (feature.getGeometry() instanceof OlPoint) {
     feature.setStyle(
-      createPointGeometryStyle(7, color, "white", 1, pointSymbol),
+      createPointGeometryStyle(7, color, "white", 2, pointSymbol),
     );
   } else {
     fillOpacity = typeof fillOpacity === "number" ? fillOpacity : 0.25;

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@
 
 import { Color, PaletteMode } from "@mui/material";
 import {
+  blue,
   brown,
   cyan,
   green,
@@ -34,6 +35,7 @@ import {
   pink,
   purple,
   red,
+  teal,
   yellow,
 } from "@mui/material/colors";
 
@@ -244,9 +246,10 @@ interface TileAccess {
 }
 
 // Array of user place colors in stable order (see #153)
-const userPlaceColorsArray: [string, Color][] = [
+export const userPlaceColorsArray: [string, Color][] = [
   ["red", red],
   ["yellow", yellow],
+  ["blue", blue],
   ["pink", pink],
   ["lightBlue", lightBlue],
   ["green", green],
@@ -256,6 +259,7 @@ const userPlaceColorsArray: [string, Color][] = [
   ["indigo", indigo],
   ["cyan", cyan],
   ["brown", brown],
+  ["teal", teal],
 ];
 
 const userPlaceColors: { [name: string]: Color } = (() => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ import { AuthClientConfig } from "@/util/auth";
 import { Branding, parseBranding } from "@/util/branding";
 import baseUrl from "@/util/baseurl";
 import { buildPath } from "@/util/path";
+import { isNumber } from "./util/types";
 
 export const appParams = new URLSearchParams(window.location.search);
 
@@ -288,6 +289,13 @@ export function getUserPlaceColor(
 ): string {
   const shade = getStrokeShade(paletteMode);
   return userPlaceColors[colorName][shade];
+}
+
+export function getUserPlaceFillOpacity(opacity?: number): number {
+  if (!isNumber(opacity)) {
+    opacity = Config.instance.branding.polygonFillOpacity;
+  }
+  return isNumber(opacity) ? opacity : 0.25;
 }
 
 // See resources/maps.json

--- a/src/connected/PlaceSelect.tsx
+++ b/src/connected/PlaceSelect.tsx
@@ -26,7 +26,11 @@ import { connect } from "react-redux";
 
 import _PlaceSelect from "@/components/PlaceSelect";
 import { AppState } from "@/states/appState";
-import { renameUserPlace, removeUserPlace } from "@/actions/dataActions";
+import {
+  renameUserPlace,
+  removeUserPlace,
+  restyleUserPlace,
+} from "@/actions/dataActions";
 import {
   selectPlace,
   locateSelectedPlaceInMap,
@@ -35,6 +39,7 @@ import {
 import {
   selectedPlaceGroupPlacesSelector,
   selectedPlaceGroupPlaceLabelsSelector,
+  selectedPlaceInfoSelector,
 } from "@/selectors/controlSelectors";
 
 const mapStateToProps = (state: AppState) => {
@@ -43,6 +48,7 @@ const mapStateToProps = (state: AppState) => {
     datasets: state.dataState.datasets,
     selectedPlaceGroupIds: state.controlState.selectedPlaceGroupIds,
     selectedPlaceId: state.controlState.selectedPlaceId,
+    selectedPlaceInfo: selectedPlaceInfoSelector(state),
     places: selectedPlaceGroupPlacesSelector(state),
     placeLabels: selectedPlaceGroupPlaceLabelsSelector(state),
   };
@@ -51,6 +57,7 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = {
   selectPlace,
   renameUserPlace,
+  restyleUserPlace,
   removeUserPlace,
   locateSelectedPlace: locateSelectedPlaceInMap,
   openDialog,

--- a/src/connected/StatisticsPanel.tsx
+++ b/src/connected/StatisticsPanel.tsx
@@ -26,6 +26,7 @@ import { connect } from "react-redux";
 
 import { AppState } from "@/states/appState";
 import {
+  resolvedStatisticsRecordsSelector,
   selectedDatasetSelector,
   selectedDatasetTimeLabelSelector,
   selectedPlaceInfoSelector,
@@ -33,6 +34,7 @@ import {
 } from "@/selectors/controlSelectors";
 import _StatisticsPanel from "@/components/StatisticsPanel";
 import { addStatistics, removeStatistics } from "@/actions/dataActions";
+import { statisticsLoadingSelector } from "@/selectors/dataSelectors";
 
 const mapStateToProps = (state: AppState) => {
   return {
@@ -40,8 +42,8 @@ const mapStateToProps = (state: AppState) => {
     selectedVariable: selectedVariableSelector(state),
     selectedTime: selectedDatasetTimeLabelSelector(state),
     selectedPlaceInfo: selectedPlaceInfoSelector(state),
-    statisticsLoading: state.dataState.statistics.loading,
-    statisticsRecords: state.dataState.statistics.records,
+    statisticsLoading: statisticsLoadingSelector(state),
+    statisticsRecords: resolvedStatisticsRecordsSelector(state),
   };
 };
 

--- a/src/model/place.ts
+++ b/src/model/place.ts
@@ -56,13 +56,20 @@ export interface PlaceGroup extends GeoJSON.FeatureCollection {
 }
 
 /**
+ * Style part of PlaceInfo
+ */
+export interface PlaceStyle {
+  color: string;
+  opacity: number;
+}
+
+/**
  * Computed place information.
  */
-export interface PlaceInfo {
+export interface PlaceInfo extends PlaceStyle {
   placeGroup: PlaceGroup;
   place: Place;
   label: string;
-  color: string;
   image: string | null;
   description: string | null;
 }
@@ -101,6 +108,7 @@ export const DEFAULT_DESCRIPTION_PROPERTY_NAMES = mkCases([
   "comment",
 ]);
 export const DEFAULT_COLOR_PROPERTY_NAMES = mkCases(["color"]);
+export const DEFAULT_OPACITY_PROPERTY_NAMES = mkCases(["opacity"]);
 export const DEFAULT_IMAGE_PROPERTY_NAMES = mkCases([
   "image",
   "img",
@@ -128,6 +136,14 @@ export function computePlaceInfo(
     "color",
     getUserPlaceColorName(getPlaceHash(place)),
     DEFAULT_COLOR_PROPERTY_NAMES,
+  );
+  updatePlaceInfo(
+    infoObj,
+    placeGroup,
+    place,
+    "opacity",
+    0.2,
+    DEFAULT_OPACITY_PROPERTY_NAMES,
   );
   updatePlaceInfo(
     infoObj,

--- a/src/model/place.ts
+++ b/src/model/place.ts
@@ -29,6 +29,7 @@ import { default as OlGeometry } from "ol/geom/Geometry";
 
 import { getUserPlaceColorName } from "@/config";
 import { newId } from "@/util/id";
+import { isString } from "@/util/types";
 
 export const USER_ID_PREFIX = "user-";
 
@@ -261,8 +262,21 @@ export function forEachPlace(
 
 export function findPlaceInfo(
   placeGroups: PlaceGroup[],
+  placeId: string,
+): PlaceInfo | null;
+export function findPlaceInfo(
+  placeGroups: PlaceGroup[],
   predicate: (placeGroup: PlaceGroup, place: Place) => boolean,
+): PlaceInfo | null;
+export function findPlaceInfo(
+  placeGroups: PlaceGroup[],
+  placeIdOrPredicate:
+    | string
+    | ((placeGroup: PlaceGroup, place: Place) => boolean),
 ): PlaceInfo | null {
+  const predicate = isString(placeIdOrPredicate)
+    ? (_placeGroup: PlaceGroup, place: Place) => place.id === placeIdOrPredicate
+    : placeIdOrPredicate;
   for (const placeGroup of placeGroups) {
     if (isValidPlaceGroup(placeGroup)) {
       const place = placeGroup.features.find((place: Place) =>

--- a/src/reducers/dataReducer.ts
+++ b/src/reducers/dataReducer.ts
@@ -54,7 +54,12 @@ import { SELECT_TIME_RANGE, SelectTimeRange } from "@/actions/controlActions";
 import i18n from "@/i18n";
 import { newId } from "@/util/id";
 import { Variable } from "@/model/variable";
-import { Place, PlaceGroup, USER_DRAWN_PLACE_GROUP_ID } from "@/model/place";
+import {
+  Place,
+  PlaceGroup,
+  PlaceStyle,
+  USER_DRAWN_PLACE_GROUP_ID,
+} from "@/model/place";
 import { TimeSeries, TimeSeriesGroup } from "@/model/timeSeries";
 import { getDatasetUserVariables } from "@/model/dataset";
 
@@ -574,7 +579,7 @@ function updateUserPlaceGroup(
   userPlaceGroups: PlaceGroup[],
   placeGroupId: string,
   placeId: string,
-  placeProperties: Record<string, unknown>,
+  placeProperties: PlaceStyle | Record<string, unknown>,
 ) {
   const pgIndex = userPlaceGroups.findIndex((pg) => pg.id === placeGroupId);
   if (pgIndex >= 0) {

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -281,6 +281,11 @@
       "se": "Omvänt"
     },
     {
+      "en": "Color",
+      "de": "Farbe",
+      "se": "Färg"
+    },
+    {
       "en": "Opacity",
       "de": "Opazität",
       "se": "Opacitet"

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -72,6 +72,7 @@ import { findIndexCloseTo } from "@/util/find";
 import {
   predefinedColorBarsSelector,
   datasetsSelector,
+  statisticsRecordsSelector,
   timeSeriesGroupsSelector,
   userPlaceGroupsSelector,
   userServersSelector,
@@ -104,6 +105,7 @@ import {
 } from "@/model/layerDefinition";
 import { UserVariable } from "@/model/userVariable";
 import { encodeDatasetId, encodeVariableName } from "@/model/encode";
+import { StatisticsRecord } from "@/model/statistics";
 
 export const selectedDatasetIdSelector = (state: AppState) =>
   state.controlState.selectedDatasetId;
@@ -513,10 +515,7 @@ export const selectedPlaceInfoSelector = createSelector(
     if (placeGroups.length === 0 || placeId === null) {
       return null;
     }
-    return findPlaceInfo(
-      placeGroups,
-      (_placeGroup, place) => place.id === placeId,
-    );
+    return findPlaceInfo(placeGroups, placeId);
   },
 );
 
@@ -595,6 +594,33 @@ export const timeSeriesPlaceInfosSelector = createSelector(
       }
     });
     return placeInfos;
+  },
+);
+
+export const resolvedStatisticsRecordsSelector = createSelector(
+  statisticsRecordsSelector,
+  selectedDatasetAndUserPlaceGroupsSelector,
+  (
+    statisticsRecords: StatisticsRecord[],
+    placeGroups: PlaceGroup[],
+  ): StatisticsRecord[] => {
+    const resolvedStatisticsRecords: StatisticsRecord[] = [];
+    statisticsRecords.forEach((statisticsRecord) => {
+      const placeId = statisticsRecord.source.placeInfo.place.id;
+      forEachPlace(placeGroups, (placeGroup, place) => {
+        if (place.id === placeId) {
+          const placeInfo = getPlaceInfo(placeGroup, place);
+          resolvedStatisticsRecords.push({
+            ...statisticsRecord,
+            source: {
+              ...statisticsRecord.source,
+              placeInfo,
+            },
+          });
+        }
+      });
+    });
+    return resolvedStatisticsRecords;
   },
 );
 

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -1089,7 +1089,7 @@ export function getTileUrl(
 }
 
 export function getDefaultFillOpacity() {
-  return Config.instance.branding.polygonFillOpacity || 0.25;
+  return Config.instance.branding.polygonFillOpacity || 0.2;
 }
 
 export function getDefaultStyleImage() {

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -38,7 +38,7 @@ import { default as OlStyle } from "ol/style/Style";
 import { default as OlTileGrid } from "ol/tilegrid/TileGrid";
 import { LoadFunction } from "ol/Tile";
 
-import { Config, getTileAccess } from "@/config";
+import { Config, getTileAccess, getUserPlaceFillOpacity } from "@/config";
 import { Layers } from "@/components/ol/layer/Layers";
 import { Tile } from "@/components/ol/layer/Tile";
 import { Vector } from "@/components/ol/layer/Vector";
@@ -1089,7 +1089,7 @@ export function getTileUrl(
 }
 
 export function getDefaultFillOpacity() {
-  return Config.instance.branding.polygonFillOpacity || 0.2;
+  return getUserPlaceFillOpacity();
 }
 
 export function getDefaultStyleImage() {

--- a/src/selectors/dataSelectors.tsx
+++ b/src/selectors/dataSelectors.tsx
@@ -44,6 +44,10 @@ export const userServersSelector = (state: AppState) =>
   state.dataState.userServers || [];
 export const expressionCapabilitiesSelector = (state: AppState) =>
   state.dataState.expressionCapabilities;
+export const statisticsLoadingSelector = (state: AppState) =>
+  state.dataState.statistics.loading;
+export const statisticsRecordsSelector = (state: AppState) =>
+  state.dataState.statistics.records;
 
 export const placeGroupsSelector = createSelector(
   datasetsSelector,


### PR DESCRIPTION
We can now change color and opacity of user drawn points and shapes. Also, improved visual style of selected places in the map.

![image](https://github.com/user-attachments/assets/fa476fc3-a8c3-44a1-ad1a-b4585f3156ca)


Closes #216
Closes #97 

To verify:

- Draw several polygon places
- Create timeseries and statistics for them
- Next to the place selector find the new style editor
- Change color and opacity --> shape should change style accordingly
- See also the colors of timeseries and statistics changing
- Test for points too 
