### PR TITLE
Renamed internal color mapping types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,11 @@
   (screen turned white). It reproducibly occurred when first computing 
   statistics for a point and then for a polygon. (#376)
 
+### Other changes
+
+* Renamed internal color mapping types from `"node"`, `"bound"`, `"key"`
+  into `"continuous"`, `"stepwise"`, `"categorical"`.
+
 ## Changes in version 1.2.1
 
 * Updated language translations for German and Swedish in the statistics panel.

--- a/src/components/ColorBarLegend/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegend.tsx
@@ -100,7 +100,7 @@ export default function ColorBarLegend(
   }
 
   const variableTitleWithUnits =
-    variableColorBar.type === "key"
+    variableColorBar.type === "categorical"
       ? variableTitle || variableName
       : `${variableTitle || variableName} (${variableUnits || "-"})`;
 
@@ -109,7 +109,7 @@ export default function ColorBarLegend(
       <Box sx={styles.title} component="span">
         {variableTitleWithUnits}
       </Box>
-      {variableColorBar.type === "key" ? (
+      {variableColorBar.type === "categorical" ? (
         <ColorBarLegendCategorical
           categories={variableColorBar.colorRecords}
           onOpenColorBarEditor={handleOpenColorBarSelect}

--- a/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
+++ b/src/components/ColorBarLegend/ColorMapTypeEditor.tsx
@@ -39,13 +39,23 @@ const styles = makeStyles({
 });
 
 const typeLabels: [ColorMapType, string, string][] = [
-  ["node", "Contin.", "Continuous color mapping where values are nodes"],
   [
-    "bound",
-    "Stepwise",
-    "Stepwise color mapping where values are bounds of ranges",
+    "continuous",
+    "Contin.",
+    "Continuous color assignment, where each value represents" +
+      " a support point of a color gradient",
   ],
-  ["key", "Categ.", "Values and their colors represent categories/classes"],
+  [
+    "stepwise",
+    "Stepwise",
+    "Stepwise color mapping where values are bounds of value" +
+      " ranges mapped to the same single color",
+  ],
+  [
+    "categorical",
+    "Categ.",
+    "Values represent unique categories or indexes that are mapped to a color",
+  ],
 ];
 
 interface ColorMapTypeEditorProps {

--- a/src/model/userColorBar.test.ts
+++ b/src/model/userColorBar.test.ts
@@ -30,14 +30,14 @@ import {
 } from "./userColorBar";
 
 describe("Assert that colorBar.getUserColorBarRgbaArray()", () => {
-  it("works as expected if type='node'", () => {
+  it("works as expected if type='continuous'", () => {
     const data = getUserColorBarRgbaArray(
       [
         { value: 0.0, color: [35, 255, 82, 255] },
         { value: 0.5, color: [255, 0, 0, 255] },
         { value: 1.0, color: [120, 30, 255, 255] },
       ],
-      "node",
+      "continuous",
       10,
     );
     expect(data).toBeInstanceOf(Uint8ClampedArray);
@@ -48,14 +48,14 @@ describe("Assert that colorBar.getUserColorBarRgbaArray()", () => {
     ]);
   });
 
-  it("works as expected if type='key'", () => {
+  it("works as expected if type='categorical'", () => {
     const data = getUserColorBarRgbaArray(
       [
         { value: 0.0, color: [35, 255, 82, 255] },
         { value: 0.5, color: [255, 0, 0, 255] },
         { value: 1.0, color: [120, 30, 255, 255] },
       ],
-      "key",
+      "categorical",
       10,
     );
     expect(data).toBeInstanceOf(Uint8ClampedArray);

--- a/src/model/userColorBar.ts
+++ b/src/model/userColorBar.ts
@@ -31,7 +31,7 @@ export const USER_COLOR_BAR_CODE_EXAMPLE =
   "0.5: red\n" + // tie point 2
   "1.0: 120,30,255"; // tie point 3
 
-export type ColorMapType = "key" | "bound" | "node";
+export type ColorMapType = "continuous" | "stepwise" | "categorical";
 
 export interface UserColorBar {
   /**
@@ -50,8 +50,7 @@ export interface UserColorBar {
    */
   code: string;
   /**
-   * Type of color mapping, discrete (= "key" or "bounds") or
-   * continuous (= "node").
+   * Type of color mapping.
    */
   type: ColorMapType;
   /**
@@ -72,8 +71,8 @@ export function getUserColorBarRgbaArray(
 ): Uint8ClampedArray {
   const rgbaArray = new Uint8ClampedArray(4 * size);
   const n = records.length;
-  if (type === "key" || type === "bound") {
-    const m = type === "key" ? n : n - 1;
+  if (type === "categorical" || type === "stepwise") {
+    const m = type === "categorical" ? n : n - 1;
     for (let i = 0, j = 0; i < size; i++, j += 4) {
       const recordIndex = Math.floor((m * i) / size);
       const [r, g, b, a] = records[recordIndex].color;

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -347,7 +347,7 @@ export function controlReducer(
         userColorBars: [
           {
             id: id,
-            type: "node",
+            type: "continuous",
             code: USER_COLOR_BAR_CODE_EXAMPLE,
           },
           ...state.userColorBars,

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -966,19 +966,19 @@
       "se": "Kateg."
     },
     {
-      "en": "Continuous color mapping where values are nodes",
-      "de": "Kontinuierliche Farbzuordnung, bei der Werte Knoten sind",
-      "se": "Kontinuerlig färgkartläggning där värden är noder"
+      "en": "Continuous color assignment, where each value represents a support point of a color gradient",
+      "de": "Kontinuierliche Farbzuordnung, bei der jeder Wert eine Stützstelle eines Farbverlaufs darstellt",
+      "se": "Kontinuerlig färgtilldelning där varje värde representerar en punkt i en färggradient"
     },
     {
-      "en": "Stepwise color mapping where values are bounds of ranges",
-      "de": "Schrittweise Farbzuordnung, bei der die Werte Bereichsgrenzen darstellen",
+      "en": "Stepwise color mapping where values are bounds of value ranges mapped to the same color",
+      "de": "Schrittweise Farbzuordnung, bei der die Werte Bereichsgrenzen darstellen, die einer einzelnen Frabe zugeordnet werden",
       "se": "Stegvis färgmappning där värden är gränser för intervall"
     },
     {
-      "en": "Values and their colors represent categories/classes",
-      "de": "Werte und deren Farben repräsentieren Kategorien/Klassen",
-      "se": "Värden och deras färger representerar kategorier/klasser"
+      "en": "Values represent unique categories or indexes that are mapped to a color",
+      "de": "Werte stellen eindeutige Kategorien oder Indizes dar, die einer Farbe zugeordnet sind",
+      "se": "Värden representerar unika kategorier eller index som är mappade till en färg"
     },
     {
       "en": "User",

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -27,6 +27,8 @@ import { ApiServerConfig } from "@/model/apiServer";
 import { getLocalStorage } from "@/util/storage";
 import { ControlState } from "./controlState";
 import { UserVariable } from "@/model/userVariable";
+import { ColorMapType } from "@/model/userColorBar";
+import { isString } from "@/util/types";
 
 export function storeUserServers(userServers: ApiServerConfig[]) {
   const storage = getLocalStorage(Config.instance.name);
@@ -174,7 +176,12 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
       storage.getStringProperty("selectedOverlayId", settings, defaultSettings);
       storage.getArrayProperty("userBaseMaps", settings, defaultSettings);
       storage.getArrayProperty("userOverlays", settings, defaultSettings);
-      storage.getArrayProperty("userColorBars", settings, defaultSettings);
+      storage.getArrayProperty(
+        "userColorBars",
+        settings,
+        defaultSettings,
+        convertColorBarsFrom16To17,
+      );
       storage.getStringProperty(
         "userDrawnPlaceGroupName",
         settings,
@@ -217,4 +224,29 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
     console.warn("User settings not found or access denied");
   }
   return defaultSettings;
+}
+
+/* Translates old color map types names to currently used names */
+const _COLOR_MAP_TYPES: Record<string, ColorMapType> = {
+  node: "continuous",
+  continuous: "continuous",
+  bound: "stepwise",
+  stepwise: "stepwise",
+  key: "categorical",
+  categorical: "categorical",
+};
+
+function convertColorBarsFrom16To17(colorBars: unknown) {
+  if (Array.isArray(colorBars)) {
+    return colorBars.map((colorBar: Record<string, unknown>) => ({
+      ...colorBar,
+      type: convertColorBarTypeFrom16To17(colorBar.type),
+    }));
+  }
+}
+
+function convertColorBarTypeFrom16To17(type: unknown): ColorMapType {
+  return isString(type) && type in _COLOR_MAP_TYPES
+    ? _COLOR_MAP_TYPES[type]
+    : "continuous";
 }


### PR DESCRIPTION
- Renamed internal color mapping types from `"node"`, `"bound"`, `"key"` into `"continuous"`, `"stepwise"`, `"categorical"`.
- Adjusted tooltip texts.

Requires https://github.com/xcube-dev/xcube/pull/1049