### PR TITLE
Update help text for color mapping

### DIFF
--- a/public/docs/color-mappings.de.md
+++ b/public/docs/color-mappings.de.md
@@ -18,8 +18,7 @@ Die Interpretation des `<value>` hängt vom ausgewählten Farbzuordnungstyp ab
   `<value>` eine Stützstelle eines Farbverlaufs darstellt.
 * **Schrittweise:** Schrittweise Farbzuordnung, bei der die Werte 
   Bereichsgrenzen darstellen, die einer einzelnen Farbe zugeordnet werden.
-  Die `<color>` wird dem ersten `<value>` jeder Grenze zugeordnet. Der letzte 
-  Farbwert wird ignoriert.
+  Eine `<color>` wird dem ersten `<value>` eines Grenzbereiches zugeordnet. Der letzte Farbwert wird ignoriert.
 * **Kategorisch:** Werte stellen eindeutige Kategorien oder Indizes dar, 
   die einer Farbe zugeordnet sind. Der Inhalt des Datensatzes sowie der 
   `<value>` muss dem Typ Integer entsprechen. Wenn eine Kategorie keinen 

--- a/public/docs/color-mappings.de.md
+++ b/public/docs/color-mappings.de.md
@@ -14,13 +14,14 @@ Hexadezimale Werte können auch mit einem Alpha-Wert geschrieben werden, wie `#F
 
 Die Interpretation des `<value>` hängt vom ausgewählten Farbzuordnungstyp ab
 
-* Typ **Node**: Die Farbkodierung ist ein linearer Verlauf zwischen den Farben 
-  mit relativen Abständen, die durch `<value>` angegeben werden, welche 
-  die Kontrollwerte oder _Knoten_ darstellen.
-* Typ **Bound**: Angrenzende Werte bilden Wertgrenzen (bounds), die der `<color>` 
-  zugeordnet sind, die mit dem ersten `<value>` der Grenze verbunden ist. Der 
-  letzte Farbwert wird daher ignoriert.
-* Typ **Key**: Die Werte sind ganze Zahlen, die direkt die zugehörige Farbe 
-  identifizieren. Sollte für Daten des Typs Integer verwendet werden. Zusammen 
-  mit einer kategorischen Normalisierung **CAT** ermöglicht dieser Farbzuordnungstyp 
-  auch eine kategorische Kartenlegende. 
+* **Kontinuierlich:** Kontinuierliche Farbzuordnung, bei der jeder 
+  `<value>` eine Stützstelle eines Farbverlaufs darstellt.
+* **Schrittweise:** Schrittweise Farbzuordnung, bei der die Werte 
+  Bereichsgrenzen darstellen, die einer einzelnen Farbe zugeordnet werden.
+  Die `<color>` wird dem ersten `<value>` jeder Grenze zugeordnet. Der letzte 
+  Farbwert wird ignoriert.
+* **Kategorisch:** Werte stellen eindeutige Kategorien oder Indizes dar, 
+  die einer Farbe zugeordnet sind. Der Inhalt des Datensatzes sowie der 
+  `<value>` muss dem Typ Integer entsprechen. Wenn eine Kategorie keinen 
+  `<value>` in der Farbzuordnung hat, wird diese transparent dargestellt. 
+  Geeignet für kategorische Datensätze. 

--- a/public/docs/color-mappings.de.md
+++ b/public/docs/color-mappings.de.md
@@ -18,7 +18,8 @@ Die Interpretation des `<value>` hängt vom ausgewählten Farbzuordnungstyp ab
   `<value>` eine Stützstelle eines Farbverlaufs darstellt.
 * **Schrittweise:** Schrittweise Farbzuordnung, bei der die Werte 
   Bereichsgrenzen darstellen, die einer einzelnen Farbe zugeordnet werden.
-  Eine `<color>` wird dem ersten `<value>` eines Grenzbereiches zugeordnet. Der letzte Farbwert wird ignoriert.
+  Eine `<color>` wird dem ersten `<value>` eines Grenzbereiches zugeordnet. 
+  Der letzte Farbwert wird ignoriert.
 * **Kategorisch:** Werte stellen eindeutige Kategorien oder Indizes dar, 
   die einer Farbe zugeordnet sind. Der Inhalt des Datensatzes sowie der 
   `<value>` muss dem Typ Integer entsprechen. Wenn eine Kategorie keinen 

--- a/public/docs/color-mappings.en.md
+++ b/public/docs/color-mappings.en.md
@@ -19,7 +19,8 @@ type:
 * **Continuous:** Continuous color assignment, where each `<value>` 
   represents a support point of a color gradient.
 * **Stepwise:** Stepwise color mapping where values are bounds of value 
-  ranges mapped to the same color. A `<color>` gets associated with the first `<value>` of each boundary range, while the last color gets ignored.
+  ranges mapped to the same color. A `<color>` gets associated with the 
+  first `<value>` of each boundary range, while the last color gets ignored.
 * **Categorical:** Values represent unique categories or indexes that are 
   mapped to a color. The data and the `<value>` must be of type integer. 
   If a category does not have a `<value>` in the color mapping, it will be 

--- a/public/docs/color-mappings.en.md
+++ b/public/docs/color-mappings.en.md
@@ -18,8 +18,8 @@ type:
 
 * **Continuous:** Continuous color assignment, where each `<value>` 
   represents a support point of a color gradient.
-* **Stepwise:** Stepwise color mapping where values are bounds of value 
-  ranges mapped to the same color. A `<color>` gets associated with the 
+* **Stepwise:** Stepwise color mapping where values within the range of two
+  subsequent `<value>`s are mapped to the same color. A `<color>` gets associated with the 
   first `<value>` of each boundary range, while the last color gets ignored.
 * **Categorical:** Values represent unique categories or indexes that are 
   mapped to a color. The data and the `<value>` must be of type integer. 

--- a/public/docs/color-mappings.en.md
+++ b/public/docs/color-mappings.en.md
@@ -19,8 +19,7 @@ type:
 * **Continuous:** Continuous color assignment, where each `<value>` 
   represents a support point of a color gradient.
 * **Stepwise:** Stepwise color mapping where values are bounds of value 
-  ranges mapped to the same color. The `<color>` get associated with the 
-  first `<value>` of each boundary. The last color value is ignored.
+  ranges mapped to the same color. A `<color>` gets associated with the first `<value>` of each boundary range, while the last color gets ignored.
 * **Categorical:** Values represent unique categories or indexes that are 
   mapped to a color. The data and the `<value>` must be of type integer. 
   If a category does not have a `<value>` in the color mapping, it will be 

--- a/public/docs/color-mappings.en.md
+++ b/public/docs/color-mappings.en.md
@@ -16,13 +16,14 @@ such as `#FFA500CD`.
 The interpretation of the `<value>` depends on the selected color mapping 
 type:
 
-* Type **Node**: The color mapping is a linear gradient between the colors 
-  with relative distances given by `<value>`, which provide the control 
-  values or _nodes_.
-* Type **Bound**: Adjacent values form value _bounds_ which map to the 
-  `<color>` associated with the first `<value>` of the boundary.
-  The last color value is therefore ignored.
-* Type **Key**: The values are integer keys that directly identify 
-  the associated color. Should be used for data of type integer.
-  Together with a categorical normalisation **CAT**, 
-  this color mapping type will also allow for a categorical map legend. 
+* **Continuous:** Continuous color assignment, where each `<value>` 
+  represents a support point of a color gradient.
+* **Stepwise:** Stepwise color mapping where values are bounds of value 
+  ranges mapped to the same color. The `<color>` get associated with the 
+  first `<value>` of each boundary. The last color value is ignored.
+* **Categorical:** Values represent unique categories or indexes that are 
+  mapped to a color. The data and the `<value>` must be of type integer. 
+  If a category does not have a `<value>` in the color mapping, it will be 
+  displayed as transparent. Suitable for categorical datasets.
+
+

--- a/public/docs/color-mappings.se.md
+++ b/public/docs/color-mappings.se.md
@@ -5,7 +5,8 @@ syntaxen `<value>`: `<color>`, där `<color>` kan vara
 * en lista med RGB-värden, med värden i intervallet 0 till 255, 
   till exempel, `255,165,0` för färgen Orange;
 * ett hexadecimalt RGB-värde, t.ex. `#FFA500`;
-* eller ett giltigt [HTML-färgnamn](https://www.w3schools.com/colors/colors_names.asp) som `Orange`, `BlanchedAlmond` eller `MediumSeaGreen`.
+* eller ett giltigt [HTML-färgnamn](https://www.w3schools.com/colors/colors_names.asp) 
+  som `Orange`, `BlanchedAlmond` eller `MediumSeaGreen`.
 
 Färgvärdet kan kompletteras med ett opacitetsvärde (alpha-värde) i 
 intervallet 0 till 1, till exempel `110,220,230,0.5` eller `#FFA500,0.8` 

--- a/public/docs/color-mappings.se.md
+++ b/public/docs/color-mappings.se.md
@@ -1,24 +1,27 @@
-A user-defined color mapping associates data values or ranges of data values 
-with color values. The lines in the text box have the general syntax 
-`<value>: <color>`, where `<color>` can be
+En användardefinierad färgkarta associerar datavärden eller intervall 
+av datavärden med färgvärden. Raderna i textrutan har den allmänna 
+syntaxen <värde>: <färg>, där <färg> kan vara
 
-* a list of RGB values, with values in the range 0 to 255, for example,
-  `255,165,0` for the color Orange;
-* a hexadecimal RGB value, e.g., `#FFA500`;
-* or a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp)
-  such as `Orange`, `BlanchedAlmond` or `MediumSeaGreen`.
+* en lista med RGB-värden, med värden i intervallet 0 till 255, 
+  till exempel, 255,165,0 för färgen Orange;
+* ett hexadecimalt RGB-värde, t.ex. #FFA500;
+* eller ett giltigt HTML-färgnamn som Orange, BlanchedAlmond eller 
+  MediumSeaGreen.
 
-Färgvärdet kan kompletteras med ett opacitetsvärde (alpha-värde) i intervallet 0 
-till 1, till exempel `110,220,230,0.5` eller `#FFA500,0.8` eller `Blue,0`. 
-Hexadecimala värden kan också skrivas med ett alpha-värde, såsom `#FFA500CD`.
+Färgvärdet kan kompletteras med ett opacitetsvärde (alpha-värde) i 
+intervallet 0 till 1, till exempel `110,220,230,0.5` eller `#FFA500,0.8` 
+eller `Blue,0`. Hexadecimala värden kan också skrivas med ett alpha-värde, 
+såsom `#FFA500CD`.
 
 Tolkningen av `<value>` beror på den valda färgkartläggningstypen:
 
-* Typ **Node**: Färgkartläggningen är en linjär gradient mellan färgerna med
-  relativa avstånd givna av `<value>`, som ger kontrollvärdena eller _noderna_.
-* Typ **Bound**: Angränsande värden bildar värdegränser (_bounds_), som kartläggs
-  till den `<color>` som är associerad med det första `<value>` av gränsen.
-  Det sista färgvärdet ignoreras därför.
-* Typ **Key**: Värdena är heltal som direkt identifierar den associerade färgen. 
-  Bör användas för data av typen heltal. Tillsammans med en kategorisk normalisering 
-  **CAT** möjliggör denna färgkartläggningstyp också en kategorisk kartlegenda.
+* **Kontinuerlig:** Kontinuerlig färgtilldelning där varje `<value>` 
+  representerar en punkt i en färggradient.
+* **Stegvis:** Stegvis färgmappning där värden är gränser för intervall 
+  `<color>` associeras med det första `<value>` i varje gräns. Det sista 
+  färgvärdet ignoreras.
+* **Kategorisk:** Värden representerar unika kategorier eller index som 
+  är mappade till en färg. Innehållet i datasetet samt `<value>` måste 
+  vara av typ Integer. Om en kategori inte har något `<value>` i 
+  färgkartan, kommer den att visas som genomskinlig. Lämplig för 
+  kategoriska dataset.

--- a/public/docs/color-mappings.se.md
+++ b/public/docs/color-mappings.se.md
@@ -1,6 +1,6 @@
 En användardefinierad färgkarta associerar datavärden eller intervall 
 av datavärden med färgvärden. Raderna i textrutan har den allmänna 
-syntaxen <värde>: <färg>, där <färg> kan vara
+syntaxen <value>: <color>, där <color> kan vara
 
 * en lista med RGB-värden, med värden i intervallet 0 till 255, 
   till exempel, 255,165,0 för färgen Orange;
@@ -17,9 +17,9 @@ Tolkningen av `<value>` beror på den valda färgkartläggningstypen:
 
 * **Kontinuerlig:** Kontinuerlig färgtilldelning där varje `<value>` 
   representerar en punkt i en färggradient.
-* **Stegvis:** Stegvis färgmappning där värden är gränser för intervall 
-  `<color>` associeras med det första `<value>` i varje gräns. Det sista 
-  färgvärdet ignoreras.
+* **Stegvis:** Stegvis färgmappning där värden är gränser för intervall. 
+  En `<color>` associeras med det första `<value>` i gränsintervall, medan 
+  den sista färgen ignoreras.
 * **Kategorisk:** Värden representerar unika kategorier eller index som 
   är mappade till en färg. Innehållet i datasetet samt `<value>` måste 
   vara av typ Integer. Om en kategori inte har något `<value>` i 

--- a/public/docs/color-mappings.se.md
+++ b/public/docs/color-mappings.se.md
@@ -1,12 +1,11 @@
 En användardefinierad färgkarta associerar datavärden eller intervall 
 av datavärden med färgvärden. Raderna i textrutan har den allmänna 
-syntaxen <value>: <color>, där <color> kan vara
+syntaxen `<value>`: `<color>`, där `<color>` kan vara
 
 * en lista med RGB-värden, med värden i intervallet 0 till 255, 
-  till exempel, 255,165,0 för färgen Orange;
-* ett hexadecimalt RGB-värde, t.ex. #FFA500;
-* eller ett giltigt HTML-färgnamn som Orange, BlanchedAlmond eller 
-  MediumSeaGreen.
+  till exempel, `255,165,0` för färgen Orange;
+* ett hexadecimalt RGB-värde, t.ex. `#FFA500`;
+* eller ett giltigt [HTML-färgnamn](https://www.w3schools.com/colors/colors_names.asp) som `Orange`, `BlanchedAlmond` eller `MediumSeaGreen`.
 
 Färgvärdet kan kompletteras med ett opacitetsvärde (alpha-värde) i 
 intervallet 0 till 1, till exempel `110,220,230,0.5` eller `#FFA500,0.8` 

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -972,7 +972,7 @@
     },
     {
       "en": "Stepwise color mapping where values are bounds of value ranges mapped to the same color",
-      "de": "Schrittweise Farbzuordnung, bei der die Werte Bereichsgrenzen darstellen, die einer einzelnen Frabe zugeordnet werden",
+      "de": "Schrittweise Farbzuordnung, bei der die Werte Bereichsgrenzen darstellen, die einer einzelnen Farbe zugeordnet werden",
       "se": "Stegvis färgmappning där värden är gränser för intervall"
     },
     {


### PR DESCRIPTION
This PR:
- updates the help text for the simplified color mapping
- fixes a small typo.