### PR TITLE
Use tile layer extent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,10 @@
   - The value range can now be assigned from the value range
     of the color mapping values.
 
+* Map layers that represent dataset variable's will no longer request
+  tiles for regions that do not intersect with the dataset's extent. 
+  This improves both viewer and server performance. (#412)
+
 * All selectable items of the variable legend (color bar, value range)
   now show a "pointer" cursor to indicate interactivity.
 

--- a/src/components/ol/layer/common.ts
+++ b/src/components/ol/layer/common.ts
@@ -42,6 +42,7 @@ export function processLayerProperties(
   updateLayerProperty(layer, prevProps, nextProps, "visible", true);
   updateLayerProperty(layer, prevProps, nextProps, "opacity", 1.0);
   updateLayerProperty(layer, prevProps, nextProps, "zIndex", undefined);
+  updateLayerProperty(layer, prevProps, nextProps, "extent", undefined);
   updateLayerProperty(layer, prevProps, nextProps, "minResolution", undefined);
   updateLayerProperty(layer, prevProps, nextProps, "maxResolution", undefined);
   // TODO: add more props here


### PR DESCRIPTION
Map layers that represent dataset variable's will no longer request tiles for regions that do not intersect with the dataset's extent. This improves both viewer and server performance. 

Closes #412