### PR TITLE
Make time dimension optional for Statistics panel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 ### New Features 
 
 * Users can now copy snapshots of a time-series charts and statistics
-  into the clipboard by clicking a new camera icon on a chart's action bar.    
+  into the clipboard by clicking a new camera icon on a chart's action bar.
   (#290)
 
 * It is now possible to change the color and opacity of user places

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@
 ### Fixes
 
 * The `<Time>` parameter is now no longer required to calculate the statistics 
-  of the selected Point/Polygon for datasets that does not contain a time 
-  parameter. (#421)
+  of the selected Point/Polygon for datasets that do not contain a time 
+  dimension. (#421)
+
 
 ## Changes in version 1.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,17 @@
 ## Changes in version 1.3.1 (in development)
 
+### Fixes
+
+* The `<Time>` parameter is now no longer required to calculate the statistics 
+  of the selected Point/Polygon for datasets that does not contain a time 
+  parameter. (#421)
 
 ## Changes in version 1.3.0
 
 ### New Features 
 
 * Users can now copy snapshots of a time-series charts and statistics
-  into the clipboard by clicking a new camera icon on a chart's action bar.
+  into the clipboard by clicking a new camera icon on a chart's action bar.    
   (#290)
 
 * It is now possible to change the color and opacity of user places

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -535,8 +535,7 @@ export function addStatistics() {
       !(
         selectedDataset &&
         selectedVariable &&
-        selectedPlaceInfo &&
-        selectedTimeLabel
+        selectedPlaceInfo
       )
     ) {
       return;

--- a/src/api/getStatistics.ts
+++ b/src/api/getStatistics.ts
@@ -47,10 +47,10 @@ export function getStatistics(
   dataset: Dataset,
   variable: Variable,
   placeInfo: PlaceInfo,
-  timeLabel: string,
+  timeLabel: string | null,
   accessToken: string | null,
 ): Promise<StatisticsRecord> {
-  const query: QueryComponent[] = [["time", timeLabel]];
+  const query: QueryComponent[] = timeLabel !== null ? [["time", timeLabel]] : [];
   const url = makeRequestUrl(
     `${apiServerUrl}/statistics/${encodeDatasetId(dataset)}/${encodeVariableName(variable)}`,
     query,

--- a/src/components/StatisticsPanel/StatisticsRow.tsx
+++ b/src/components/StatisticsPanel/StatisticsRow.tsx
@@ -83,17 +83,19 @@ export default function StatisticsRow({
   ) : (
     <Missing phrase="Variable" />
   );
+  const isTimeDimensionAvailable = dataset?.dimensions.some((data: { name: string; }) => data.name == "time")
   const timeLabel = time ? (
     isoDateTimeStringToLabel(time)
-  ) : (
+  ) : isTimeDimensionAvailable ? (
     <Missing phrase="Time" />
-  );
+  ) : null;
   const placeLabel = placeInfo ? placeInfo.label : <Missing phrase="Place" />;
   return (
     <Box sx={styles.container} ref={containerRef}>
       <Box sx={styles.header}>
         <Typography fontSize="small">
-          {datasetLabel} / {variableLabel}, {timeLabel}, {placeLabel}
+          {datasetLabel} / {variableLabel}
+          {timeLabel &&`, ${timeLabel}`}, {placeLabel}
         </Typography>
         <Box sx={styles.actions}>{actions}</Box>
       </Box>

--- a/src/model/statistics.ts
+++ b/src/model/statistics.ts
@@ -29,7 +29,7 @@ import { PlaceInfo } from "./place";
 export interface StatisticsSource {
   dataset: Dataset;
   variable: Variable;
-  time: string;
+  time: string | null;
   placeInfo: PlaceInfo;
 }
 

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -627,18 +627,15 @@ export const timeSeriesPlaceInfosSelector = createSelector(
 export const canAddStatisticsSelector = createSelector(
   selectedDatasetIdSelector,
   selectedVariableNameSelector,
-  selectedTimeSelector,
   selectedPlaceIdSelector,
   (
     selectedDatasetId: string | null,
     selectedVariableName: string | null,
-    selectedTime: Time | null,
     selectedPlaceId: string | null,
   ): boolean => {
     return !!(
       selectedDatasetId &&
       selectedVariableName &&
-      selectedTime &&
       selectedPlaceId
     );
   },


### PR DESCRIPTION
This PR removes the time dimension to be required for calculating the stats for datasets that do not have a time dimension making the time optional. It also toggles the missing `<Time?>` based on the availability of that dimension

Closes #421 