### PR TITLE
Read the docs link updated to new documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -228,7 +228,7 @@
 ### Other changes
 
 * Inlined the help menu into the app bar. The help icon button now opens the
-  [xcube Viewer documentation](https://xcube.readthedocs.io/en/latest/viewer.html)
+  [xcube Viewer documentation](https://xcube-dev.github.io/xcube-viewer/)
   in a new browser tab.
 
 * No longer obtaining Roboto font from Google servers.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   of the selected Point/Polygon for datasets that do not contain a time 
   dimension. (#421)
 
+* The help icon button now opens the new documentation [xcube Viewer documentation]
+(https://xcube-dev.github.io/xcube-viewer/) in a new browser tab.
 
 ## Changes in version 1.3.0
 
@@ -228,7 +230,7 @@
 ### Other changes
 
 * Inlined the help menu into the app bar. The help icon button now opens the
-  [xcube Viewer documentation](https://xcube-dev.github.io/xcube-viewer/)
+  [xcube Viewer documentation](https://xcube.readthedocs.io/en/latest/viewer.html)
   in a new browser tab.
 
 * No longer obtaining Roboto font from Google servers.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xcube Viewer
 
-A simple viewer component for [xcube](https://xcube-dev.github.io/xcube-viewer/).
+A simple viewer component for [xcube](https://xcube.readthedocs.io/).
 
 ![xcube-viewer](./docs/assets/images/xcube-viewer.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xcube Viewer
 
-A simple viewer component for [xcube](https://xcube.readthedocs.io/).
+A simple viewer component for [xcube](https://xcube-dev.github.io/xcube-viewer/).
 
 ![xcube-viewer](./docs/assets/images/xcube-viewer.png)
 
@@ -126,7 +126,7 @@ and use its properties in components
 
 ## More
 
-* [User Guide](https://xcube.readthedocs.io/en/latest/viewer.html#)
+* [User Guide](https://xcube-dev.github.io/xcube-viewer/)
 * [Planned Enhancements](https://github.com/xcube-dev/xcube-viewer/labels/enhancement)
 * [Known Issues](https://github.com/xcube-dev/xcube-viewer/labels/bug)
 

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -142,7 +142,7 @@ const _AppBar: React.FC<AppBarProps> = ({
   };
 
   const handleOpenManual = () => {
-    window.open("https://xcube.readthedocs.io/en/latest/viewer.html", "Manual");
+    window.open(" https://xcube-dev.github.io/xcube-viewer/", "Manual");
   };
 
   const handleOpenImprint = () => {

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -142,7 +142,7 @@ const _AppBar: React.FC<AppBarProps> = ({
   };
 
   const handleOpenManual = () => {
-    window.open(" https://xcube-dev.github.io/xcube-viewer/", "Manual");
+    window.open("https://xcube-dev.github.io/xcube-viewer/", "Manual");
   };
 
   const handleOpenImprint = () => {


### PR DESCRIPTION
This PR is to replace old URLs with the new user guide link for the xcube viewer user guide. 