### PR TITLE
Add tooltips to the metadata section of the sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
     - `mui` from v5 to v6
     - `testing-library/react` from v12 to v16
 
+* Tooltips (incl. translation) have been added to the toogle buttons that 
+  control the format of the metadata information in the sidebar.
+
 ## Changes in version 1.3.1
 
 ### Fixes

--- a/src/components/InfoPanel/InfoPanel.tsx
+++ b/src/components/InfoPanel/InfoPanel.tsx
@@ -557,7 +557,9 @@ const InfoCardContent: React.FC<InfoCardContentProps> = ({
               size="small"
               sx={commonStyles.toggleButton}
             >
+            <Tooltip arrow title={i18n.get("Textual format")}>
               <TextFieldsIcon />
+            </Tooltip>
             </ToggleButton>
             <ToggleButton
               key={1}
@@ -565,7 +567,9 @@ const InfoCardContent: React.FC<InfoCardContentProps> = ({
               size="small"
               sx={commonStyles.toggleButton}
             >
+            <Tooltip arrow title={i18n.get("Tabular format")}>
               <ListAltIcon />
+            </Tooltip>
             </ToggleButton>
             <ToggleButton
               key={2}
@@ -573,7 +577,9 @@ const InfoCardContent: React.FC<InfoCardContentProps> = ({
               size="small"
               sx={commonStyles.toggleButton}
             >
+            <Tooltip arrow title={i18n.get("JSON format")}>
               <JsonIcon />
+            </Tooltip>
             </ToggleButton>
             {hasPython && (
               <ToggleButton

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -1226,6 +1226,21 @@
       "se": "Får inte vara tom"
     },
     {
+      "en": "Textual format",
+      "de": "Textformat",
+      "se": "Textformat"
+    },
+    {
+      "en": "Tabular format",
+      "de": "Tabellenformat",
+      "se": "Tabellformat"
+    },
+    {
+      "en": "JSON format",
+      "de": "JSON-Format",
+      "se": "JSON-format"
+    },
+    {
       "en": "docs/privacy-note.en.md",
       "de": "docs/privacy-note.de.md",
       "se": "docs/privacy-note.se.md"


### PR DESCRIPTION
This PR:

- add tooltips (incl. translation) to the toogle buttons that control the format of the metadata information in the sidebar.