### PR TITLE
New "share" action that creates a state permalink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 ## Changes in version 1.4.0 (in development)
 
+### Enhancements
+
+* Added a new "share" action to the app bar.
+  It creates a permalink URL to restore the view state 
+  and copies it to the clipboard. (#447)
+  
+  The restored state includes
+  - Selected map region, zoom level, and overlays.
+  - User places including the selected place.
+  - Opened panels, active tabs, and any selected options.
+  - Other UI-specific states such as selected items, filters, or toggle states.
+
 ### Other changes
 
 * Updated dependencies, development dependencies and updated TypeScript code base accordingly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcube-viewer",
-  "version": "1.4.0-dev.0",
+  "version": "1.4.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcube-viewer",
-      "version": "1.4.0-dev.0",
+      "version": "1.4.0-dev.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "1.4.0-dev.0",
+  "version": "1.4.0-dev.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -864,15 +864,28 @@ export function syncWithServer(store: Store, init: boolean = false) {
 
     const stateKey = appParams.get("stateKey");
     if (stateKey && init) {
+      const serverUrl = selectedServerSelector(store.getState()).url;
       api
         .getViewerState(
-          selectedServerSelector(store.getState()).url,
+          serverUrl,
           getState().userAuthState.accessToken,
           stateKey,
         )
         .then((persistedState) => {
           if (persistedState) {
-            dispatch(applyPersistentState(persistedState) as unknown as Action);
+            const { apiUrl } = persistedState;
+            if (apiUrl === serverUrl) {
+              dispatch(
+                applyPersistentState(persistedState) as unknown as Action,
+              );
+            } else {
+              dispatch(
+                postMessage(
+                  "warning",
+                  "Failed to restore state, backend mismatch",
+                ),
+              );
+            }
           }
         });
     }

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -156,9 +156,9 @@ export function shareStatePermalink() {
         getState().userAuthState.accessToken,
         newPersistentAppState(getState()),
       )
-      .then((stateId) => {
-        if (stateId) {
-          const viewerUrl = `${baseUrl.origin}?stateId=${stateId}`;
+      .then((stateKey) => {
+        if (stateKey) {
+          const viewerUrl = `${baseUrl.origin}?stateKey=${stateKey}`;
           navigator.clipboard.writeText(viewerUrl).then(() => {
             dispatch(
               postMessage("success", i18n.get("Permalink copied to clipboard")),
@@ -862,13 +862,13 @@ export function syncWithServer(store: Store, init: boolean = false) {
       api: { serverUrl: apiServer.url, endpointName: "viewer/ext" },
     });
 
-    const stateId = appParams.get("stateId");
-    if (stateId && init) {
+    const stateKey = appParams.get("stateKey");
+    if (stateKey && init) {
       api
         .getViewerState(
           selectedServerSelector(store.getState()).url,
           getState().userAuthState.accessToken,
-          stateId,
+          stateKey,
         )
         .then((persistedState) => {
           if (persistedState) {

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -135,6 +135,43 @@ export function _updateServerInfo(serverInfo: ApiServerInfo): UpdateServerInfo {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+const SHARE_STATE_PERMALINK = "SHARE_STATE_PERMALINK";
+
+export function shareStatePermalink() {
+  return (
+    dispatch: Dispatch<AddActivity | RemoveActivity | MessageLogAction>,
+    getState: () => AppState,
+  ) => {
+    const apiServer = selectedServerSelector(getState());
+    dispatch(
+      addActivity(SHARE_STATE_PERMALINK, i18n.get("Creating permalink")),
+    );
+    api
+      .putViewerState(
+        apiServer.url,
+        getState().userAuthState.accessToken,
+        getState().controlState as unknown as Record<string, unknown>,
+      )
+      .then((stateId) => {
+        if (stateId) {
+          const viewerUrl = `${window.location}?stateId=${stateId}`;
+          navigator.clipboard.writeText(viewerUrl).then(() => {
+            dispatch(
+              postMessage("success", i18n.get("Permalink copied to clipboard")),
+            );
+          });
+        } else {
+          dispatch(
+            postMessage("error", i18n.get("Failed to create permalink")),
+          );
+        }
+      })
+      .finally(() => dispatch(removeActivity(SHARE_STATE_PERMALINK)));
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 export const UPDATE_RESOURCES = "UPDATE_RESOURCES";
 
 export function updateResources() {

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -95,7 +95,7 @@ import {
   setSidebarPanelId,
 } from "./controlActions";
 import baseUrl from "@/util/baseurl";
-import { newPersistentAppState } from "@/states/persistedState";
+import { newPersistentAppState, PersistedState } from "@/states/persistedState";
 import { applyPersistentState } from "@/actions/otherActions";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -871,9 +871,10 @@ export function syncWithServer(store: Store, init: boolean = false) {
           getState().userAuthState.accessToken,
           stateKey,
         )
-        .then((persistedState) => {
-          if (persistedState) {
-            const { apiUrl } = persistedState;
+        .then((stateResult) => {
+          if (typeof stateResult === "object") {
+            const persistedState = stateResult as PersistedState;
+            const { apiUrl } = persistedState as PersistedState;
             if (apiUrl === serverUrl) {
               dispatch(
                 applyPersistentState(persistedState) as unknown as Action,
@@ -886,6 +887,8 @@ export function syncWithServer(store: Store, init: boolean = false) {
                 ),
               );
             }
+          } else {
+            dispatch(postMessage("warning", stateResult));
           }
         });
     }

--- a/src/actions/otherActions.tsx
+++ b/src/actions/otherActions.tsx
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Dispatch } from "redux";
+import { default as OlView } from "ol/View";
+
+import { PersistedMapState, PersistedState } from "@/states/persistedState";
+import { MAP_OBJECTS } from "@/states/controlState";
+import { default as OlMap } from "ol/Map";
+
+////////////////////////////////////////////////////////////////////////////////
+
+export const APPLY_PERSISTED_STATE = "APPLY_PERSISTED_STATE";
+
+export interface ApplyPersistedState {
+  type: typeof APPLY_PERSISTED_STATE;
+  persistedState: PersistedState;
+}
+
+export function applyPersistentState(persistedState: PersistedState) {
+  return (dispatch: Dispatch) => {
+    console.debug("Restoring persisted state:", persistedState);
+    dispatch(_applyPersistentState(persistedState));
+    const { mapState } = persistedState.state;
+    if (mapState) {
+      restoreMapView(mapState);
+    }
+  };
+}
+
+function _applyPersistentState(
+  persistedState: PersistedState,
+): ApplyPersistedState {
+  return { type: APPLY_PERSISTED_STATE, persistedState };
+}
+
+function restoreMapView(mapState: PersistedMapState) {
+  if (MAP_OBJECTS["map"]) {
+    console.log("Restoring map:", mapState);
+    const map = MAP_OBJECTS["map"] as OlMap;
+    map.setView(new OlView(mapState.view));
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+export type OtherAction = ApplyPersistedState;

--- a/src/api/getViewerState.ts
+++ b/src/api/getViewerState.ts
@@ -28,10 +28,10 @@ import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
 export function getViewerState(
   apiServerUrl: string,
   accessToken: string | null,
-  stateId: string,
+  stateKey: string,
 ): Promise<PersistedState | undefined> {
   const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, [
-    ["key", stateId],
+    ["key", stateKey],
   ]);
   try {
     return callJsonApi<PersistedState>(url, makeRequestInit(accessToken))

--- a/src/api/getViewerState.ts
+++ b/src/api/getViewerState.ts
@@ -22,15 +22,27 @@
  * SOFTWARE.
  */
 
-export { getColorBars } from "./getColorBars";
-export { getDatasets } from "./getDatasets";
-export { getDatasetPlaceGroup } from "./getDatasetPlaceGroup";
-export { getExpressionCapabilities } from "./getExpressionCapabilities";
-export { getServerInfo } from "./getServerInfo";
-export { getTimeSeriesForGeometry } from "./getTimeSeries";
-export { getStatistics } from "./getStatistics";
-export { getPointValue } from "./getPointValue";
-export { updateResources } from "./updateResources";
-export { getViewerState } from "./getViewerState";
-export { putViewerState } from "./putViewerState";
-export { HTTPError } from "./errors";
+import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
+
+export function getViewerState(
+  apiServerUrl: string,
+  accessToken: string | null,
+  stateId: string,
+): Promise<unknown> {
+  const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, [
+    ["stateId", stateId],
+  ]);
+  try {
+    return callJsonApi<unknown>(url, makeRequestInit(accessToken))
+      .then((state: unknown) => {
+        return state;
+      })
+      .catch((error) => {
+        console.error(error);
+        return undefined;
+      });
+  } catch (error) {
+    console.error(error);
+    return Promise.resolve(undefined);
+  }
+}

--- a/src/api/getViewerState.ts
+++ b/src/api/getViewerState.ts
@@ -22,19 +22,20 @@
  * SOFTWARE.
  */
 
+import { PersistedState } from "@/states/persistedState";
 import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
 
 export function getViewerState(
   apiServerUrl: string,
   accessToken: string | null,
   stateId: string,
-): Promise<unknown> {
+): Promise<PersistedState | undefined> {
   const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, [
-    ["stateId", stateId],
+    ["key", stateId],
   ]);
   try {
-    return callJsonApi<unknown>(url, makeRequestInit(accessToken))
-      .then((state: unknown) => {
+    return callJsonApi<PersistedState>(url, makeRequestInit(accessToken))
+      .then((state) => {
         return state;
       })
       .catch((error) => {

--- a/src/api/getViewerState.ts
+++ b/src/api/getViewerState.ts
@@ -29,21 +29,15 @@ export function getViewerState(
   apiServerUrl: string,
   accessToken: string | null,
   stateKey: string,
-): Promise<PersistedState | undefined> {
+): Promise<PersistedState | string> {
   const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, [
     ["key", stateKey],
   ]);
-  try {
-    return callJsonApi<PersistedState>(url, makeRequestInit(accessToken))
-      .then((state) => {
-        return state;
-      })
-      .catch((error) => {
-        console.error(error);
-        return undefined;
-      });
-  } catch (error) {
-    console.error(error);
-    return Promise.resolve(undefined);
-  }
+  return callJsonApi<PersistedState>(url, makeRequestInit(accessToken))
+    .then((state) => {
+      return state;
+    })
+    .catch((error) => {
+      return `${error}`;
+    });
 }

--- a/src/api/putViewerState.ts
+++ b/src/api/putViewerState.ts
@@ -22,15 +22,30 @@
  * SOFTWARE.
  */
 
-export { getColorBars } from "./getColorBars";
-export { getDatasets } from "./getDatasets";
-export { getDatasetPlaceGroup } from "./getDatasetPlaceGroup";
-export { getExpressionCapabilities } from "./getExpressionCapabilities";
-export { getServerInfo } from "./getServerInfo";
-export { getTimeSeriesForGeometry } from "./getTimeSeries";
-export { getStatistics } from "./getStatistics";
-export { getPointValue } from "./getPointValue";
-export { updateResources } from "./updateResources";
-export { getViewerState } from "./getViewerState";
-export { putViewerState } from "./putViewerState";
-export { HTTPError } from "./errors";
+import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
+
+export function putViewerState(
+  apiServerUrl: string,
+  accessToken: string | null,
+  state: Record<string, unknown>,
+): Promise<string | undefined> {
+  const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, []);
+  const init = {
+    ...makeRequestInit(accessToken),
+    method: "PUT",
+    body: JSON.stringify(state),
+  };
+  try {
+    return callJsonApi<{ stateId: string }>(url, init)
+      .then((result) => {
+        return result.stateId;
+      })
+      .catch((error) => {
+        console.error(error);
+        return undefined;
+      });
+  } catch (error) {
+    console.error(error);
+    return Promise.resolve(undefined);
+  }
+}

--- a/src/api/putViewerState.ts
+++ b/src/api/putViewerState.ts
@@ -22,12 +22,13 @@
  * SOFTWARE.
  */
 
+import { PersistedState } from "@/states/persistedState";
 import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
 
 export function putViewerState(
   apiServerUrl: string,
   accessToken: string | null,
-  state: Record<string, unknown>,
+  state: PersistedState,
 ): Promise<string | undefined> {
   const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, []);
   const init = {
@@ -36,9 +37,9 @@ export function putViewerState(
     body: JSON.stringify(state),
   };
   try {
-    return callJsonApi<{ stateId: string }>(url, init)
+    return callJsonApi<{ key: string }>(url, init)
       .then((result) => {
-        return result.stateId;
+        return result.key;
       })
       .catch((error) => {
         console.error(error);

--- a/src/components/ControlBarActions.tsx
+++ b/src/components/ControlBarActions.tsx
@@ -30,6 +30,7 @@ import Tooltip from "@mui/material/Tooltip";
 import ToggleButton from "@mui/material/ToggleButton";
 import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import ShareIcon from "@mui/icons-material/Share";
 import SettingsIcon from "@mui/icons-material/Settings";
 import ViewSidebarIcon from "@mui/icons-material/ViewSidebar";
 
@@ -54,6 +55,8 @@ interface ControlBarActionsProps extends WithLocale {
   openDialog: (dialogId: string) => void;
   allowRefresh?: boolean;
   updateResources: () => void;
+  allowSharing?: boolean;
+  shareStatePermalink: () => void;
   compact: boolean;
 }
 
@@ -64,6 +67,8 @@ export default function ControlBarActions({
   openDialog,
   allowRefresh,
   updateResources,
+  allowSharing,
+  shareStatePermalink,
   compact,
 }: ControlBarActionsProps) {
   if (!visible) {
@@ -85,6 +90,7 @@ export default function ControlBarActions({
   );
 
   let refreshButton;
+  let shareButton;
   let downloadButton;
   let settingsButton;
 
@@ -93,6 +99,14 @@ export default function ControlBarActions({
       <IconButton onClick={updateResources} size="small">
         <Tooltip arrow title={i18n.get("Refresh")}>
           <RefreshIcon />
+        </Tooltip>
+      </IconButton>
+    );
+
+    shareButton = allowSharing && (
+      <IconButton onClick={shareStatePermalink} size="small">
+        <Tooltip arrow title={i18n.get("Share")}>
+          <ShareIcon />
         </Tooltip>
       </IconButton>
     );
@@ -118,6 +132,7 @@ export default function ControlBarActions({
     <StyledFormControl variant="standard">
       <Box>
         {refreshButton}
+        {shareButton}
         {downloadButton}
         {settingsButton}
         {sidebarButton}

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -33,6 +33,7 @@ import Typography from "@mui/material/Typography";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import SettingsIcon from "@mui/icons-material/Settings";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import ShareIcon from "@mui/icons-material/Share";
 import PolicyIcon from "@mui/icons-material/Policy";
 import { deepOrange } from "@mui/material/colors";
 import CloudDownloadIcon from "@mui/icons-material/CloudDownload";
@@ -42,7 +43,7 @@ import { Config } from "@/config";
 import { AppState } from "@/states/appState";
 import { WithLocale } from "@/util/lang";
 import { openDialog } from "@/actions/controlActions";
-import { updateResources } from "@/actions/dataActions";
+import { shareStatePermalink, updateResources } from "@/actions/dataActions";
 import MarkdownPage from "@/components/MarkdownPage";
 import UserControl from "./UserControl";
 import { makeStyles } from "@/util/styles";
@@ -51,7 +52,9 @@ interface AppBarProps extends WithLocale {
   appName: string;
   openDialog: (dialogId: string) => unknown;
   allowRefresh?: boolean;
+  allowSharing?: boolean;
   updateResources: () => unknown;
+  shareStatePermalink: () => unknown;
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -60,13 +63,16 @@ const mapStateToProps = (state: AppState) => {
     locale: state.controlState.locale,
     appName: Config.instance.branding.appBarTitle,
     allowRefresh: Config.instance.branding.allowRefresh,
+    allowSharing: Config.instance.branding.allowRefresh,
   };
 };
 
 const mapDispatchToProps = {
   openDialog,
   updateResources,
+  shareStatePermalink,
 };
+
 const appBarStyle: Record<string, SxProps<Theme>> = {
   appBar: (theme: Theme) => ({
     zIndex: theme.zIndex.drawer + 1,
@@ -134,6 +140,8 @@ const _AppBar: React.FC<AppBarProps> = ({
   openDialog,
   allowRefresh,
   updateResources,
+  allowSharing,
+  shareStatePermalink,
 }: AppBarProps) => {
   const [imprintOpen, setImprintOpen] = React.useState(false);
 
@@ -185,6 +193,17 @@ const _AppBar: React.FC<AppBarProps> = ({
               sx={styles.iconButton}
             >
               <RefreshIcon />
+            </IconButton>
+          </Tooltip>
+        )}
+        {allowSharing && (
+          <Tooltip arrow title={i18n.get("Share")}>
+            <IconButton
+              onClick={shareStatePermalink}
+              size="small"
+              sx={styles.iconButton}
+            >
+              <ShareIcon />
             </IconButton>
           </Tooltip>
         )}

--- a/src/connected/ControlBarActions.tsx
+++ b/src/connected/ControlBarActions.tsx
@@ -28,7 +28,7 @@ import { AppState } from "@/states/appState";
 import _ControlBarActions from "@/components/ControlBarActions";
 import { openDialog, setSidebarOpen } from "@/actions/controlActions";
 import { Config } from "@/config";
-import { updateResources } from "@/actions/dataActions";
+import { shareStatePermalink, updateResources } from "@/actions/dataActions";
 
 const mapStateToProps = (state: AppState) => {
   return {
@@ -39,6 +39,7 @@ const mapStateToProps = (state: AppState) => {
     sidebarOpen: state.controlState.sidebarOpen,
     compact: Config.instance.branding.compact,
     allowRefresh: Config.instance.branding.allowRefresh,
+    allowSharing: Config.instance.branding.allowSharing,
   };
 };
 
@@ -46,6 +47,7 @@ const mapDispatchToProps = {
   setSidebarOpen,
   openDialog,
   updateResources,
+  shareStatePermalink,
 };
 
 const ControlBarActions = connect(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,6 +45,9 @@ import {
 import { syncWithServer } from "@/actions/dataActions";
 import { appReducer } from "@/reducers/appReducer";
 import { AppState } from "@/states/appState";
+import baseUrl from "@/util/baseurl";
+
+console.debug("baseUrl:", baseUrl);
 
 Config.load().then(() => {
   const actionFilter = (_getState: () => AppState, action: Action) =>
@@ -62,7 +65,7 @@ Config.load().then(() => {
   dispatch(changeLocale(store.getState().controlState.locale));
   dispatch(updateUserColorBarsImageData() as unknown as Action);
   if (store.getState().controlState.privacyNoticeAccepted) {
-    dispatch(syncWithServer(store) as unknown as Action);
+    dispatch(syncWithServer(store, true) as unknown as Action);
   }
 
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -85,6 +85,7 @@ import { findIndexCloseTo } from "@/util/find";
 import { appParams } from "@/config";
 import { USER_DRAWN_PLACE_GROUP_ID } from "@/model/place";
 import { USER_COLOR_BAR_CODE_EXAMPLE } from "@/model/userColorBar";
+import { APPLY_PERSISTED_STATE, OtherAction } from "@/actions/otherActions";
 
 // TODO (forman): Refactor reducers for UPDATE_DATASETS, SELECT_DATASET,
 //  SELECT_PLACE, SELECT_VARIABLE so they produce a consistent state.
@@ -98,13 +99,17 @@ import { USER_COLOR_BAR_CODE_EXAMPLE } from "@/model/userColorBar";
 
 export function controlReducer(
   state: ControlState | undefined,
-  action: ControlAction | DataAction,
+  action: ControlAction | DataAction | OtherAction,
   appState: AppState | undefined,
 ): ControlState {
   if (state === undefined) {
     state = newControlState();
   }
   switch (action.type) {
+    case APPLY_PERSISTED_STATE: {
+      const { controlState } = action.persistedState.state;
+      return { ...state, ...controlState };
+    }
     case UPDATE_SETTINGS: {
       const settings = { ...state, ...action.settings };
       storeUserSettings(settings);

--- a/src/reducers/dataReducer.ts
+++ b/src/reducers/dataReducer.ts
@@ -62,15 +62,20 @@ import {
 } from "@/model/place";
 import { TimeSeries, TimeSeriesGroup } from "@/model/timeSeries";
 import { getDatasetUserVariables } from "@/model/dataset";
+import { APPLY_PERSISTED_STATE, OtherAction } from "@/actions/otherActions";
 
 export function dataReducer(
   state: DataState | undefined,
-  action: DataAction | SelectTimeRange,
+  action: DataAction | SelectTimeRange | OtherAction,
 ): DataState {
   if (state === undefined) {
     state = newDataState();
   }
   switch (action.type) {
+    case APPLY_PERSISTED_STATE: {
+      const { dataState } = action.persistedState.state;
+      return { ...state, ...dataState };
+    }
     case UPDATE_SERVER_INFO: {
       return { ...state, serverInfo: action.serverInfo };
     }

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -22,6 +22,7 @@
     "mapProjection": "EPSG:3857",
     "allowDownloads": true,
     "allowRefresh": true,
+    "allowSharing": true,
     "allowUserVariables": true,
     "allow3D": true
   }

--- a/src/resources/config.schema.json
+++ b/src/resources/config.schema.json
@@ -155,6 +155,10 @@
           "type": "boolean",
           "default": true
         },
+        "allowSharing": {
+          "type": "boolean",
+          "default": true
+        },
         "allowViewModePython": {
           "type": "boolean",
           "default": true

--- a/src/states/persistedState.ts
+++ b/src/states/persistedState.ts
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import version from "@/version";
+import { AppState } from "./appState";
+import { ControlState, MAP_OBJECTS } from "./controlState";
+import { DataState } from "./dataState";
+import { default as OlMap } from "ol/Map";
+
+const dataStateProps: readonly (keyof DataState)[] = [
+  "statistics",
+  "userPlaceGroups",
+];
+
+const controlStateProps: readonly (keyof ControlState)[] = [
+  "selectedDatasetId",
+  "selectedVariableName",
+  "selectedDataset2Id",
+  "selectedVariable2Name",
+  "selectedTime",
+  "selectedTimeRange",
+  "selectedUserPlaceId",
+  "selectedPlaceId",
+  "selectedPlaceGroupIds",
+  "sidebarPanelId",
+  "layerMenuOpen",
+  "sidebarOpen",
+  "sidebarPosition",
+  "variableSplitPos",
+  "variableCompareMode",
+  "selectedBaseMapId",
+  "selectedOverlayId",
+  "userBaseMaps",
+  "userOverlays",
+  "userColorBars",
+  "mapProjection",
+];
+
+type PersistedDataState = Pick<DataState, (typeof dataStateProps)[number]>;
+type PersistedControlState = Pick<
+  ControlState,
+  (typeof controlStateProps)[number]
+>;
+
+export interface PersistedMapState {
+  view: {
+    projection: string;
+    center: number[];
+    zoom?: number;
+    rotation?: number;
+  };
+}
+
+export interface PersistedState {
+  version: string;
+  state: {
+    dataState: PersistedDataState;
+    controlState: PersistedControlState;
+    mapState?: PersistedMapState;
+  };
+}
+
+export function newPersistentAppState(appState: AppState): PersistedState {
+  return {
+    version,
+    state: {
+      dataState: newSubsetState(appState.dataState, dataStateProps),
+      controlState: newSubsetState(appState.controlState, controlStateProps),
+      mapState: newMapState(),
+    },
+  };
+}
+
+function newSubsetState<S, A extends readonly (keyof S)[]>(
+  state: S,
+  keys: A,
+): Pick<S, A[number]> {
+  const subsetState: Record<string, unknown> = {};
+  keys.forEach((k) => {
+    subsetState[k as string] = state[k];
+  });
+  return subsetState as Pick<S, A[number]>;
+}
+
+function newMapState(): PersistedMapState | undefined {
+  if (MAP_OBJECTS["map"]) {
+    const map = MAP_OBJECTS["map"] as OlMap;
+    const view = map.getView();
+    const projection = view.getProjection().getCode();
+    const center = view.getCenter();
+    if (center !== undefined) {
+      const zoom = view.getZoom();
+      const rotation = view.getRotation();
+      return { view: { projection, center, zoom, rotation } };
+    }
+  }
+  return undefined;
+}

--- a/src/states/persistedState.ts
+++ b/src/states/persistedState.ts
@@ -27,10 +27,13 @@ import { AppState } from "./appState";
 import { ControlState, MAP_OBJECTS } from "./controlState";
 import { DataState } from "./dataState";
 import { default as OlMap } from "ol/Map";
+import { selectedServerSelector } from '@/selectors/controlSelectors';
+import baseUrl from '@/util/baseurl';
 
 const dataStateProps: readonly (keyof DataState)[] = [
-  "statistics",
   "userPlaceGroups",
+  "timeSeriesGroups",
+  "statistics",
 ];
 
 const controlStateProps: readonly (keyof ControlState)[] = [
@@ -74,6 +77,8 @@ export interface PersistedMapState {
 
 export interface PersistedState {
   version: string;
+  apiUrl: string
+  viewerUrl: string;
   state: {
     dataState: PersistedDataState;
     controlState: PersistedControlState;
@@ -84,6 +89,8 @@ export interface PersistedState {
 export function newPersistentAppState(appState: AppState): PersistedState {
   return {
     version,
+    apiUrl: selectedServerSelector(appState).url,
+    viewerUrl: baseUrl.origin,
     state: {
       dataState: newSubsetState(appState.dataState, dataStateProps),
       controlState: newSubsetState(appState.controlState, controlStateProps),

--- a/src/states/persistedState.ts
+++ b/src/states/persistedState.ts
@@ -27,8 +27,8 @@ import { AppState } from "./appState";
 import { ControlState, MAP_OBJECTS } from "./controlState";
 import { DataState } from "./dataState";
 import { default as OlMap } from "ol/Map";
-import { selectedServerSelector } from '@/selectors/controlSelectors';
-import baseUrl from '@/util/baseurl';
+import { selectedServerSelector } from "@/selectors/controlSelectors";
+import baseUrl from "@/util/baseurl";
 
 const dataStateProps: readonly (keyof DataState)[] = [
   "userPlaceGroups",
@@ -77,7 +77,8 @@ export interface PersistedMapState {
 
 export interface PersistedState {
   version: string;
-  apiUrl: string
+  creationDate: string;
+  apiUrl: string;
   viewerUrl: string;
   state: {
     dataState: PersistedDataState;
@@ -89,6 +90,7 @@ export interface PersistedState {
 export function newPersistentAppState(appState: AppState): PersistedState {
   return {
     version,
+    creationDate: new Date().toUTCString(),
     apiUrl: selectedServerSelector(appState).url,
     viewerUrl: baseUrl.origin,
     state: {

--- a/src/util/baseurl.ts
+++ b/src/util/baseurl.ts
@@ -43,5 +43,3 @@ function _getBaseUrl(): URL {
 const baseUrl = _getBaseUrl();
 
 export default baseUrl;
-
-console.log("baseUrl = ", baseUrl.href);

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -94,6 +94,7 @@ export interface Branding {
   mapProjection?: string;
   allowDownloads?: boolean;
   allowRefresh?: boolean;
+  allowSharing?: boolean;
   allowViewModePython?: boolean;
   allowUserVariables?: boolean;
   allow3D?: boolean;

--- a/src/version.ts
+++ b/src/version.ts
@@ -23,6 +23,6 @@
  */
 
 // Important: use semantic versioning (https://semver.org/)
-const version = "1.4.0-dev.0";
+const version = "1.4.0-dev.1";
 
 export default version;


### PR DESCRIPTION
Closes #447 

![image](https://github.com/user-attachments/assets/ef826135-ab75-43a7-a0a8-c80f2f1a5a06)

![image](https://github.com/user-attachments/assets/653f7a0b-74fb-405c-8240-6fe0dcc0b46c)

The restored state includes:

- [x] Selected map region, zoom level, and overlays.
- [x] User places including the selected place.
- [x] Opened panels, active tabs, and any selected options.
- [x] Other UI-specific states such as selected items, filters, or toggle states.

See https://github.com/xcube-dev/xcube/pull/1091