### PR TITLE
Fix `Dataset` and `Variable` types

### DIFF
--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -23,12 +23,12 @@
  */
 
 import { assertArrayNotEmpty, assertDefinedAndNotNull } from "@/util/assert";
-import { PlaceGroup } from "./place";
-import { TimeRange } from "./timeSeries";
-import { Variable } from "./variable";
 import { isString } from "@/util/types";
-import { UserVariable } from "@/model/userVariable";
-import { ReactNode } from "react";
+import { type UserVariable } from "@/model/userVariable";
+import { type JsonPrimitive } from "@/util/json";
+import { type PlaceGroup } from "./place";
+import { type TimeRange } from "./timeSeries";
+import { type Variable } from "./variable";
 
 export interface Dimension {
   name: string;
@@ -75,7 +75,7 @@ export interface Dataset {
   variables: Variable[];
   placeGroups?: PlaceGroup[];
   attributions?: string[];
-  attrs: Record<string, ReactNode>;
+  attrs: Record<string, JsonPrimitive | JsonPrimitive[]>;
   rgbSchema?: RgbSchema;
 }
 

--- a/src/util/json.test.ts
+++ b/src/util/json.test.ts
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { expect, it, describe } from "vitest";
+import { isJsonPrimitive, isJsonObject, isJsonArray } from "./json";
+
+describe("json", () => {
+  it("isJsonPrimitive()", () => {
+    expect(isJsonPrimitive(null)).toBe(true);
+    expect(isJsonPrimitive(false)).toBe(true);
+    expect(isJsonPrimitive(13)).toBe(true);
+    expect(isJsonPrimitive("Hello!")).toBe(true);
+
+    expect(isJsonPrimitive(undefined)).toBe(false);
+    expect(isJsonPrimitive(() => {})).toBe(false);
+    expect(isJsonPrimitive({})).toBe(false);
+    expect(isJsonPrimitive([])).toBe(false);
+  });
+
+  it("isJsonArray()", () => {
+    expect(isJsonArray([])).toBe(true);
+    expect(isJsonArray([false, "hello", [1, 2, 3]])).toBe(true);
+    expect(isJsonArray([1, undefined, 3])).toBe(true);
+    expect(isJsonArray([{ count: 3 }])).toBe(true);
+
+    expect(isJsonArray(undefined)).toBe(false);
+    expect(isJsonArray(null)).toBe(false);
+    expect(isJsonArray(true)).toBe(false);
+    expect(isJsonArray(12)).toBe(false);
+    expect(isJsonArray("hello")).toBe(false);
+    expect(isJsonArray(() => {})).toBe(false);
+    expect(isJsonArray({})).toBe(false);
+  });
+
+  it("isJsonObject()", () => {
+    expect(isJsonObject({})).toBe(true);
+    expect(isJsonObject({ name: undefined })).toBe(true);
+    expect(isJsonObject({ names: [] })).toBe(true);
+
+    expect(isJsonObject(undefined)).toBe(false);
+    expect(isJsonObject(null)).toBe(false);
+    expect(isJsonObject(true)).toBe(false);
+    expect(isJsonObject(12)).toBe(false);
+    expect(isJsonObject("hello")).toBe(false);
+    expect(isJsonObject(() => {})).toBe(false);
+    expect(isJsonObject([])).toBe(false);
+    expect(isJsonObject({ name: () => "hello" })).toBe(false);
+    expect(isJsonObject({ names: [() => "hello"] })).toBe(false);
+  });
+});

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -22,32 +22,31 @@
  * SOFTWARE.
  */
 
-import { type VolumeRenderMode } from "@/states/controlState";
-import { type JsonPrimitive } from "@/util/json";
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonArray = JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
 
-export type ColorBarNorm = "lin" | "log";
+const primitiveTypes = new Set(["boolean", "number", "string"]);
 
-export interface Variable {
-  id: string;
-  name: string;
-  dims: string[];
-  shape: number[];
-  dtype: string;
-  units: string;
-  title: string;
-  expression?: string; // user-defined variables only
-  timeChunkSize: number | null;
-  // The following are new since xcube 0.11
-  tileLevelMin?: number;
-  tileLevelMax?: number;
-  // colorBarName may be prefixed by "_alpha" and/or "_r" (reversed)
-  colorBarName: string;
-  colorBarMin: number;
-  colorBarMax: number;
-  colorBarNorm?: ColorBarNorm;
-  opacity?: number;
-  volumeRenderMode?: VolumeRenderMode;
-  volumeIsoThreshold?: number;
-  htmlRepr?: string;
-  attrs: Record<string, JsonPrimitive | JsonPrimitive[]>;
+export function isJsonValue(value: unknown): value is JsonValue {
+  return isJsonPrimitive(value) || isJsonArray(value) || isJsonObject(value);
+}
+
+export function isJsonPrimitive(value: unknown): value is JsonPrimitive {
+  return value === null || primitiveTypes.has(typeof value);
+}
+
+export function isJsonArray(value: unknown): value is JsonValue {
+  return Array.isArray(value) && value.every((v) => isJsonValue(v));
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return (
+    isRecord(value) && Object.keys(value).every((k) => isJsonValue(value[k]))
+  );
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -37,13 +37,19 @@ export function isJsonPrimitive(value: unknown): value is JsonPrimitive {
   return value === null || primitiveTypes.has(typeof value);
 }
 
-export function isJsonArray(value: unknown): value is JsonValue {
-  return Array.isArray(value) && value.every((v) => isJsonValue(v));
+export function isJsonArray(value: unknown): value is JsonArray {
+  return (
+    Array.isArray(value) &&
+    value.every((v) => v === undefined || isJsonValue(v))
+  );
 }
 
 export function isJsonObject(value: unknown): value is JsonObject {
   return (
-    isRecord(value) && Object.keys(value).every((k) => isJsonValue(value[k]))
+    isRecord(value) &&
+    Object.getOwnPropertyNames(value).every(
+      (k) => value[k] === undefined || isJsonValue(value[k]),
+    )
   );
 }
 

--- a/src/util/wms.ts
+++ b/src/util/wms.ts
@@ -24,6 +24,7 @@
 
 import WMSCapabilities from "ol/format/WMSCapabilities";
 import { HTTPError } from "@/api";
+import { isJsonObject, type JsonObject } from "./json";
 
 const parser = new WMSCapabilities();
 
@@ -32,8 +33,6 @@ export interface WmsLayerDefinition {
   title: string;
   attribution?: string;
 }
-
-type JsonObject = Record<string, unknown>;
 
 export async function fetchWmsLayers(
   url: string,
@@ -143,8 +142,4 @@ function mergeLayerObjects(
       : childTitle || parentTitle;
 
   return { ...parentLayer, ...childLayer, Title: title };
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }


### PR DESCRIPTION
@b-yogesh in Oct 2024 you changed the `attrs` property of the `Dataset` and `Variable` interfaces to use `ReactNode`. This is not acceptable for Redux-managed state types.

In this PR I introduced `util/json.ts` to fix this.
