### PR TITLE
Hide "share" button without persistence API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in version 1.4.2 (in development)
 
+* The new "share" button no longer appears if the xcube Server has no 
+  respective API configuration. (#470)
+
 * We now render the new `description` markdown properties received from
   xcube Server (see https://github.com/xcube-dev/xcube/issues/1122)
   in the info panel. (#454)

--- a/src/api/hasViewerStateApi.ts
+++ b/src/api/hasViewerStateApi.ts
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2024 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { makeRequestUrl } from "./callApi";
+
+export function hasViewerStateApi(apiServerUrl: string): Promise<boolean> {
+  const url = makeRequestUrl(`${apiServerUrl}/viewer/state`, [
+    ["key", "sentinel"],
+  ]);
+  try {
+    return fetch(url)
+      .then((response) => {
+        // status 501 = "Not Implemented"
+        return response.status !== 501;
+      })
+      .catch(() => {
+        return false;
+      });
+  } catch (_) {
+    return Promise.resolve(false);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ import { Branding, parseBranding } from "@/util/branding";
 import baseUrl from "@/util/baseurl";
 import { buildPath } from "@/util/path";
 import { isNumber } from "./util/types";
+import { hasViewerStateApi } from "@/api/hasViewerStateApi";
 
 export const appParams = new URLSearchParams(window.location.search);
 
@@ -96,6 +97,13 @@ export class Config {
     );
     branding = decodeBrandingFlag(branding, "allowUserVariables");
     branding = decodeBrandingFlag(branding, "allow3D");
+    branding = decodeBrandingFlag(branding, "allowSharing");
+    if (branding.allowSharing) {
+      const hasStateApi = await hasViewerStateApi(server.url);
+      if (!hasStateApi) {
+        branding = { ...branding, allowSharing: false };
+      }
+    }
     Config._instance = new Config(name, server, branding, authClient);
     if (import.meta.env.DEV) {
       console.debug("Configuration:", Config._instance);


### PR DESCRIPTION
The new "share" button no longer appears if the xcube Server has no respective persistence API configuration.

Closes #470 