### PR TITLE
Fixed drift while dragging splitter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in version 1.4.3 (in development)
+
+* Fixed a problem where mouse splitters used to resize 
+  two components (e.g., two layers in map view, or map view and side panels) 
+  created a drift while dragging.
+
 ## Changes in version 1.4.2
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcube-viewer",
-  "version": "1.4.2",
+  "version": "1.4.3-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcube-viewer",
-      "version": "1.4.2",
+      "version": "1.4.3-dev.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "1.4.2",
+  "version": "1.4.3-dev.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -17,7 +17,6 @@ const styles: Record<string, CSSProperties> = {
     flex: "auto", // same as "flex: 1 1 auto;"
   },
   ver: {
-    // width: "100%",
     height: "100%",
     display: "flex",
     flexFlow: "column nowrap",
@@ -65,8 +64,13 @@ export default function SplitPane({
     dir === "hor" ? { width: splitPosition } : { height: splitPosition };
 
   const handleSplitChange = (delta: number) => {
-    if (child1Ref.current && isNumber(child1Ref.current.clientWidth)) {
-      setSplitPosition(child1Ref.current.clientWidth + delta);
+    const divElement = child1Ref.current;
+    if (divElement) {
+      if (dir === "hor" && isNumber(divElement.clientWidth)) {
+        setSplitPosition(divElement.clientWidth + delta);
+      } else if (dir === "ver" && isNumber(divElement.clientHeight)) {
+        setSplitPosition(divElement.clientHeight + delta);
+      }
     }
   };
 

--- a/src/components/Splitter.tsx
+++ b/src/components/Splitter.tsx
@@ -10,30 +10,30 @@ import { makeStyles } from "@/util/styles";
 import useMouseDrag, { Point } from "@/hooks/useMouseDrag";
 
 const styles = makeStyles({
-  hor: (theme) => ({
+  hor: {
     flex: "none",
     border: "none",
     outline: "none",
+    position: "relative",
+    top: 0,
     width: "8px",
     minHeight: "100%",
     maxHeight: "100%",
     cursor: "col-resize",
-
-    backgroundColor: theme.palette.mode === "dark" ? "white" : "black",
     opacity: 0.0,
-  }),
-  ver: (theme) => ({
+  },
+  ver: {
     flex: "none",
     border: "none",
     outline: "none",
+    position: "relative",
     height: "8px",
+    left: 0,
     minWidth: "100%",
     maxWidth: "100%",
     cursor: "row-resize",
-
-    backgroundColor: theme.palette.mode === "dark" ? "white" : "black",
     opacity: 0.0,
-  }),
+  },
 });
 
 export type SplitDir = "hor" | "ver";
@@ -53,8 +53,8 @@ interface SplitterProps {
  * if direction is "ver".
  */
 export default function Splitter({ dir, onChange }: SplitterProps) {
-  const handleDrag = ([deltaX, _]: Point) => {
-    onChange(deltaX);
+  const handleDrag = ([deltaX, deltaY]: Point) => {
+    onChange(dir === "hor" ? deltaX : deltaY);
   };
   const handleMouseDown = useMouseDrag(handleDrag);
   return (

--- a/src/hooks/useMouseDrag.ts
+++ b/src/hooks/useMouseDrag.ts
@@ -14,10 +14,10 @@ export default function useMouseDrag(onMouseDrag: (delta: Point) => void) {
   const handleMouseMove = useRef((event: MouseEvent) => {
     if (event.buttons === 1 && lastPosition.current !== null) {
       event.preventDefault();
-      const { screenX, screenY } = event;
+      const { clientX, clientY } = event;
       const [lastScreenX, lastScreenY] = lastPosition.current;
-      const delta: Point = [screenX - lastScreenX, screenY - lastScreenY];
-      lastPosition.current = [screenX, screenY];
+      const delta: Point = [clientX - lastScreenX, clientY - lastScreenY];
+      lastPosition.current = [clientX, clientY];
       onMouseDrag(delta);
     }
   });
@@ -29,7 +29,7 @@ export default function useMouseDrag(onMouseDrag: (delta: Point) => void) {
       document.body.addEventListener("mousemove", handleMouseMove.current);
       document.body.addEventListener("mouseup", handleEndDrag.current);
       document.body.addEventListener("onmouseleave", handleEndDrag.current);
-      lastPosition.current = [event.screenX, event.screenY];
+      lastPosition.current = [event.clientX, event.clientY];
     }
   });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,6 +5,6 @@
  */
 
 // Important: use semantic versioning (https://semver.org/)
-const version = "1.4.2";
+const version = "1.4.3-dev.0";
 
 export default version;


### PR DESCRIPTION
Fixed a problem where mouse splitters used to resize two components (e.g., two layers in map view, or map view and side panels) created a drift while dragging.