### PR TITLE
Add `Divider` in control bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changes in version 1.4.3 (in development)
 
+### Improvements
+
+* Added a `Divider` to provide a visual separation of control bar items for
+  better clarity to the users. (#487)
+
+### Fixes and other Changes
+
 * Fixed a problem where mouse splitters used to resize 
   two components (e.g., two layers in map view, or map view and side panels) 
   created a drift while dragging.
@@ -10,6 +17,7 @@
   - `storybook 8.6`
 
 * Added some missing language translations.
+
 
 
 ## Changes in version 1.4.2

--- a/src/components/ControlBarItem.tsx
+++ b/src/components/ControlBarItem.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from "react";
-import { Theme, styled } from "@mui/system";
+import { Theme, styled, SxProps } from "@mui/system";
 import FormControl from "@mui/material/FormControl";
 import Box from "@mui/material/Box";
 
@@ -13,21 +13,24 @@ import { WithLocale } from "@/util/lang";
 
 const StyledForm = styled(FormControl)(({ theme }: { theme: Theme }) => ({
   marginRight: theme.spacing(1),
+  marginLeft: theme.spacing(2),
 }));
 
 interface ControlBarItemProps extends WithLocale {
   label: React.ReactNode;
   control: React.ReactNode;
   actions?: React.ReactNode | null;
+  sx?: SxProps;
 }
 
 export default function ControlBarItem({
   label,
   control,
   actions,
+  sx,
 }: ControlBarItemProps) {
   return (
-    <StyledForm variant="standard">
+    <StyledForm variant="standard" sx={sx}>
       <Box>
         {label}
         {control}

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -118,6 +118,7 @@ export default function DatasetSelect({
       label={datasetSelectLabel}
       control={datasetSelect}
       actions={locateDatasetButton}
+      sx={{ marginLeft: 0 }}
     />
   );
 }

--- a/src/connected/ControlBar.tsx
+++ b/src/connected/ControlBar.tsx
@@ -19,6 +19,7 @@ import TimeSelect from "./TimeSelect";
 import TimeSlider from "./TimeSlider";
 import TimePlayer from "./TimePlayer";
 import ControlBarActions from "./ControlBarActions";
+import Divider from "@mui/material/Divider";
 
 interface ControlBarProps extends WithLocale {
   show: boolean;
@@ -40,10 +41,13 @@ const _ControlBar: React.FC<ControlBarProps> = ({ show }) => {
   return (
     <ControlBarComponent>
       <DatasetSelect />
+      <Divider orientation={"vertical"} variant="middle" flexItem></Divider>
       <VariableSelect />
+      <Divider orientation={"vertical"} variant="middle" flexItem></Divider>
       <PlaceGroupsSelect />
       <PlaceSelect />
       <MapInteractionsBar />
+      <Divider orientation={"vertical"} variant="middle" flexItem></Divider>
       <TimeSelect />
       <TimePlayer />
       <TimeSlider />


### PR DESCRIPTION
Closes: #485 

This PR adds divider between each control items to provide a visual separation to the user.

![Screenshot from 2025-03-07 12-42-03](https://github.com/user-attachments/assets/70a3fb6f-f082-482b-adc4-463c8791d3ca)
