### PR TITLE
Fixed drift while dragging splitter, part 2

### DIFF
--- a/src/actions/controlActions.tsx
+++ b/src/actions/controlActions.tsx
@@ -336,19 +336,22 @@ export function setVariableCompareMode(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export const SET_VARIABLE_SPLIT_POS = "SET_VARIABLE_SPLIT_POS";
+export const UPDATE_VARIABLE_SPLIT_POS = "UPDATE_VARIABLE_SPLIT_POS";
 
-export interface SetVariableSplitPos {
-  type: typeof SET_VARIABLE_SPLIT_POS;
-  variableSplitPos: number | undefined;
+export interface UpdateVariableSplitPos {
+  type: typeof UPDATE_VARIABLE_SPLIT_POS;
+  size: number;
+  isDelta?: boolean;
 }
 
-export function setVariableSplitPos(
-  variableSplitPos: number | undefined,
-): SetVariableSplitPos {
+export function updateVariableSplitPos(
+  size: number,
+  isDelta?: boolean,
+): UpdateVariableSplitPos {
   return {
-    type: SET_VARIABLE_SPLIT_POS,
-    variableSplitPos,
+    type: UPDATE_VARIABLE_SPLIT_POS,
+    size,
+    isDelta,
   };
 }
 
@@ -526,15 +529,15 @@ export function setSidePanelId(sidePanelId: string | null): SetSidePanelId {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export const SET_SIDE_PANEL_SIZE = "SET_SIDE_PANEL_SIZE";
+export const UPDATE_SIDE_PANEL_SIZE = "UPDATE_SIDE_PANEL_SIZE";
 
-export interface SetSidePanelSize {
-  type: typeof SET_SIDE_PANEL_SIZE;
-  sidePanelSize: number;
+export interface UpdateSidePanelSize {
+  type: typeof UPDATE_SIDE_PANEL_SIZE;
+  sizeDelta: number;
 }
 
-export function setSidePanelSize(sidePanelSize: number): SetSidePanelSize {
-  return { type: SET_SIDE_PANEL_SIZE, sidePanelSize };
+export function updateSidePanelSize(sizeDelta: number): UpdateSidePanelSize {
+  return { type: UPDATE_SIDE_PANEL_SIZE, sizeDelta };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -817,7 +820,7 @@ export type ControlAction =
   | OpenDialog
   | CloseDialog
   | SetLayerMenuOpen
-  | SetSidePanelSize
+  | UpdateSidePanelSize
   | SetSidePanelOpen
   | SetSidePanelId
   | SetVolumeRenderMode
@@ -827,5 +830,5 @@ export type ControlAction =
   | SelectVariable2
   | SetMapPointInfoBoxEnabled
   | SetVariableCompareMode
-  | SetVariableSplitPos
+  | UpdateVariableSplitPos
   | FlyTo;

--- a/src/components/MapSplitter.tsx
+++ b/src/components/MapSplitter.tsx
@@ -31,24 +31,22 @@ type Point = [number, number];
 interface MapSplitterProps {
   hidden?: boolean;
   position?: number;
-  onPositionChange: (position: number) => void;
+  updatePosition: (size: number, isDelta?: boolean) => void;
 }
 
 export default function MapSplitter({
   hidden,
   position,
-  onPositionChange,
+  updatePosition,
 }: MapSplitterProps) {
   const divRef = useRef<HTMLDivElement | null>(null);
-  const handleDrag = useCallback(
+  const onDragMove = useCallback(
     ([offsetX, _]: Point) => {
-      if (isNumber(position) && divRef.current !== null) {
-        onPositionChange(position + offsetX);
-      }
+      updatePosition(offsetX, true);
     },
-    [position, onPositionChange],
+    [updatePosition],
   );
-  const handleMouseDown = useMouseDrag({ onDragMove: handleDrag });
+  const handleMouseDown = useMouseDrag({ onDragMove });
 
   useEffect(() => {
     if (
@@ -57,11 +55,9 @@ export default function MapSplitter({
       divRef.current !== null &&
       divRef.current!.parentElement !== null
     ) {
-      onPositionChange(
-        Math.round(divRef.current.parentElement.clientWidth / 2),
-      );
+      updatePosition(Math.round(divRef.current.parentElement.clientWidth / 2));
     }
-  }, [hidden, position, onPositionChange]);
+  }, [hidden, position, updatePosition]);
 
   if (hidden) {
     return null;

--- a/src/components/SplitPane.stories.tsx
+++ b/src/components/SplitPane.stories.tsx
@@ -5,7 +5,7 @@ import SplitPane, { SplitPaneProps } from "./SplitPane";
 
 type SplitPaneDemoProps = Omit<
   SplitPaneProps,
-  "style" | "childSize" | "setChildSize"
+  "style" | "childSize" | "updateChildSize"
 >;
 
 function SplitPaneDemo(props: SplitPaneDemoProps) {
@@ -13,7 +13,7 @@ function SplitPaneDemo(props: SplitPaneDemoProps) {
   return (
     <SplitPane
       childSize={childSize}
-      setChildSize={setChildSize}
+      updateChildSize={(delta) => setChildSize(childSize + delta)}
       {...props}
       style={{ width: 400, height: 300 }}
     >

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -84,7 +84,7 @@ export interface SplitPaneProps {
   dir: "hor" | "ver";
   childPos?: "first" | "last";
   childSize: number;
-  setChildSize: (childSize: number) => void;
+  updateChildSize: (childSize: number) => void;
   style?: CSSProperties;
   children: React.ReactNode[];
 }
@@ -97,7 +97,7 @@ export default function SplitPane({
   dir,
   childPos,
   childSize,
-  setChildSize,
+  updateChildSize,
   children,
   style,
 }: PropsWithChildren<SplitPaneProps>) {
@@ -110,10 +110,9 @@ export default function SplitPane({
   const onDragMove = useCallback(
     ([deltaX, deltaY]: [number, number]) => {
       const sizeDelta = dir === "hor" ? deltaX : deltaY;
-      const newChildSize = childSize + (isFirst ? sizeDelta : -sizeDelta);
-      setChildSize(newChildSize);
+      updateChildSize(isFirst ? sizeDelta : -sizeDelta);
     },
-    [dir, isFirst, childSize, setChildSize],
+    [dir, isFirst, updateChildSize],
   );
 
   // The handler for a mouse-down event

--- a/src/connected/MapSplitter.tsx
+++ b/src/connected/MapSplitter.tsx
@@ -8,7 +8,7 @@ import { connect } from "react-redux";
 
 import { AppState } from "@/states/appState";
 import _MapSplitter from "@/components/MapSplitter";
-import { setVariableSplitPos } from "@/actions/controlActions";
+import { updateVariableSplitPos } from "@/actions/controlActions";
 
 const mapStateToProps = (state: AppState) => {
   return {
@@ -18,7 +18,7 @@ const mapStateToProps = (state: AppState) => {
 };
 
 const mapDispatchToProps = {
-  onPositionChange: setVariableSplitPos,
+  updatePosition: updateVariableSplitPos,
 };
 
 const MapSplitter = connect(mapStateToProps, mapDispatchToProps)(_MapSplitter);

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "@mui/material";
 import Box from "@mui/material/Box";
 
 import { AppState } from "@/states/appState";
-import { setSidePanelSize } from "@/actions/controlActions";
+import { updateSidePanelSize } from "@/actions/controlActions";
 import SplitPane from "@/components/SplitPane";
 import Viewer from "./Viewer";
 import SidePanel from "./SidePanel";
@@ -55,7 +55,7 @@ interface WorkspaceImplProps {
   sidePanelOpen: boolean;
   sidePanelId: string | null;
   sidePanelSize: number;
-  setSidePanelSize: (sidebarPos: number) => void;
+  updateSidePanelSize: (sizeDelta: number) => void;
 }
 
 // noinspection JSUnusedLocalSymbols
@@ -69,7 +69,7 @@ const mapStateToProps = (state: AppState) => {
 
 // noinspection JSUnusedGlobalSymbols
 const mapDispatchToProps = {
-  setSidePanelSize,
+  updateSidePanelSize,
 };
 
 type Layout = "hor" | "ver";
@@ -81,7 +81,7 @@ function WorkspaceImpl({
   sidePanelOpen,
   sidePanelId,
   sidePanelSize,
-  setSidePanelSize,
+  updateSidePanelSize,
 }: WorkspaceImplProps) {
   const [map, setMap] = useState<OlMap | null>(null);
   const [layout, setLayout] = useState<Layout>(getLayout());
@@ -113,7 +113,7 @@ function WorkspaceImpl({
           dir={layout}
           childPos={"last"}
           childSize={sidePanelSize}
-          setChildSize={setSidePanelSize}
+          updateChildSize={updateSidePanelSize}
           style={layout === "hor" ? styles.containerHor : styles.containerVer}
         >
           <Viewer onMapRef={setMap} theme={theme} />

--- a/src/hooks/useMouseDrag.ts
+++ b/src/hooks/useMouseDrag.ts
@@ -33,21 +33,17 @@ export default function useMouseDrag({
   onDragMove,
   onDragEnd,
 }: DragOptions) {
-  const firstPosRef = useRef<[number, number] | null>(null);
-
-  const onDragMoveRef = useRef(onDragMove);
-  useEffect(() => {
-    onDragMoveRef.current = onDragMove;
-  }, [onDragMove]);
+  const lastPosRef = useRef<[number, number] | null>(null);
 
   const _handleMouseMove = useCallback(
     (event: MouseEvent) => {
-      if (event.buttons === 1 && firstPosRef.current !== null) {
+      if (event.buttons === 1 && lastPosRef.current !== null) {
         event.preventDefault();
         if (onDragMove) {
           const { clientX, clientY } = event;
-          const [firstPosX, firstPosY] = firstPosRef.current;
-          onDragMove([clientX - firstPosX, clientY - firstPosY], event);
+          const [lastPosX, lastPosY] = lastPosRef.current;
+          lastPosRef.current = [clientX, clientY];
+          onDragMove([clientX - lastPosX, clientY - lastPosY], event);
         }
       }
     },
@@ -65,7 +61,7 @@ export default function useMouseDrag({
       if (event.buttons === 1) {
         // console.info("handleMouseDown!");
         event.preventDefault();
-        firstPosRef.current = [event.clientX, event.clientY];
+        lastPosRef.current = [event.clientX, event.clientY];
         const _handleEndDrag = handleEndDragRef.current;
         document.body.addEventListener("mousemove", handleMouseMove);
         document.body.addEventListener("mouseup", _handleEndDrag);
@@ -79,10 +75,10 @@ export default function useMouseDrag({
 
   const handleEndDrag = useCallback(
     (event: MouseEvent) => {
-      if (firstPosRef.current !== null) {
+      if (lastPosRef.current !== null) {
         // console.info("handleEndDrag!");
         event.preventDefault();
-        firstPosRef.current = null;
+        lastPosRef.current = null;
         const _handleEndDrag = handleEndDragRef.current;
         document.body.removeEventListener("mousemove", handleMouseMove);
         document.body.removeEventListener("mouseup", _handleEndDrag);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,8 +22,8 @@ import App from "@/connected/App";
 import { Config } from "@/config";
 import {
   changeLocale,
-  SET_SIDE_PANEL_SIZE,
-  SET_VARIABLE_SPLIT_POS,
+  UPDATE_SIDE_PANEL_SIZE,
+  UPDATE_VARIABLE_SPLIT_POS,
   updateUserColorBarsImageData,
 } from "@/actions/controlActions";
 import { syncWithServer } from "@/actions/dataActions";
@@ -35,8 +35,8 @@ console.debug("baseUrl:", baseUrl);
 
 Config.load().then(() => {
   const actionFilter = (_getState: () => AppState, action: Action) =>
-    action.type !== SET_VARIABLE_SPLIT_POS &&
-    action.type !== SET_SIDE_PANEL_SIZE;
+    action.type !== UPDATE_VARIABLE_SPLIT_POS &&
+    action.type !== UPDATE_SIDE_PANEL_SIZE;
   const logger = ReduxLogger.createLogger({
     collapsed: true,
     diff: false,

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -26,17 +26,17 @@ import {
   SET_LAYER_MENU_OPEN,
   SET_LAYER_VISIBILITY,
   SET_MAP_INTERACTION,
-  SET_SIDE_PANEL_OPEN,
-  SET_SIDE_PANEL_ID,
-  SET_SIDE_PANEL_SIZE,
   SET_MAP_POINT_INFO_BOX_ENABLED,
+  SET_SIDE_PANEL_ID,
+  SET_SIDE_PANEL_OPEN,
   SET_VARIABLE_COMPARE_MODE,
-  SET_VARIABLE_SPLIT_POS,
+  UPDATE_VARIABLE_SPLIT_POS,
   SET_VISIBLE_INFO_CARD_ELEMENTS,
   SET_VOLUME_RENDER_MODE,
   STORE_SETTINGS,
   UPDATE_INFO_CARD_ELEMENT_VIEW_MODE,
   UPDATE_SETTINGS,
+  UPDATE_SIDE_PANEL_SIZE,
   UPDATE_TIME_ANIMATION,
   UPDATE_USER_COLOR_BAR,
   UPDATE_VOLUME_STATE,
@@ -57,13 +57,14 @@ import {
   getDatasetTimeRange,
 } from "@/model/dataset";
 import {
-  selectedDatasetTimeIndexSelector,
   selectedDatasetTimeCoordinatesSelector,
+  selectedDatasetTimeIndexSelector,
 } from "@/selectors/controlSelectors";
 import { AppState } from "@/states/appState";
 import { ControlState, newControlState } from "@/states/controlState";
 import { storeUserSettings } from "@/states/userSettings";
 import { findIndexCloseTo } from "@/util/find";
+import { isNumber } from "@/util/types";
 import { appParams } from "@/config";
 import { USER_DRAWN_PLACE_GROUP_ID } from "@/model/place";
 import { USER_COLOR_BAR_CODE_EXAMPLE } from "@/model/userColorBar";
@@ -212,9 +213,14 @@ export function controlReducer(
       const { variableCompareMode } = action;
       return { ...state, variableCompareMode, variableSplitPos: undefined };
     }
-    case SET_VARIABLE_SPLIT_POS: {
-      const { variableSplitPos } = action;
-      return { ...state, variableSplitPos };
+    case UPDATE_VARIABLE_SPLIT_POS: {
+      const { size, isDelta } = action;
+      if (!isDelta && state.variableSplitPos !== size) {
+        return { ...state, variableSplitPos: size };
+      } else if (isNumber(state.variableSplitPos) && size !== 0) {
+        return { ...state, variableSplitPos: state.variableSplitPos + size };
+      }
+      return state;
     }
     case SELECT_TIME: {
       let { selectedTime } = action;
@@ -421,10 +427,11 @@ export function controlReducer(
       storeUserSettings(state);
       return state;
     }
-    case SET_SIDE_PANEL_SIZE: {
-      const { sidePanelSize } = action;
-      state = { ...state, sidePanelSize };
-      return state;
+    case UPDATE_SIDE_PANEL_SIZE: {
+      const { sizeDelta } = action;
+      return sizeDelta
+        ? { ...state, sidePanelSize: state.sidePanelSize + sizeDelta }
+        : state;
     }
     case SET_VOLUME_RENDER_MODE: {
       state = {


### PR DESCRIPTION
This PR allows handlers passed as options to hook `useMouseDrag()` be stable w.r.t. current drag position. Before the PR, this hook created new `onMouseClick` handlers after every position change, because the input handlers were not stable.

