### PR TITLE
Enable selecting initial dataset to be shown on the viewer app from config file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in version 1.5.1 (in development)
+
+### Improvements
+
+* The viewer application now respects the server-configured initial dataset.
+
 ## Changes in version 1.5.0
 
 ### Improvements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,12 @@
 ### Improvements
 
 * The viewer application now respects the server-configured initial dataset.
+   See https://github.com/xcube-dev/xcube/issues/1135.
 
 * Updated the dataset selector to use `sortValue` from the server configuration 
- for sorting datasets within groups if provided.
+  for sorting datasets within groups if provided.
+  See https://github.com/xcube-dev/xcube/issues/1135.
+
 
 ## Changes in version 1.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 * The viewer application now respects the server-configured initial dataset.
 
+* Updated the dataset selector to use `sortValue` from the server configuration 
+ for sorting datasets within groups if provided.
+
 ## Changes in version 1.5.0
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "1.5.0",
+  "version": "1.5.1.dev0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -205,7 +205,8 @@ export function updateDatasets() {
       .getDatasets(apiServer.url, getState().userAuthState.accessToken)
       .then((ds_response: DatasetsResponse) => {
         // Add user variables from local storage
-        let { datasets, entrypoint_dataset_id } = ds_response;
+        let datasets = ds_response.datasets;
+        const entrypoint_dataset_id = ds_response.entrypoint_dataset_id;
         const userVariables = loadUserVariables();
         datasets = datasets.map((ds) => ({
           ...ds,

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -192,7 +192,7 @@ export const UPDATE_DATASETS = "UPDATE_DATASETS";
 export interface UpdateDatasets {
   type: typeof UPDATE_DATASETS;
   datasets: Dataset[];
-  entrypoint_dataset_id?: string;
+  entrypointDatasetId?: string;
 }
 
 export function updateDatasets() {
@@ -206,7 +206,7 @@ export function updateDatasets() {
       .then((ds_response: DatasetsResponse) => {
         // Add user variables from local storage
         let datasets = ds_response.datasets;
-        const entrypoint_dataset_id = ds_response.entrypoint_dataset_id;
+        const entrypointDatasetId = ds_response.entrypointDatasetId;
         const userVariables = loadUserVariables();
         if (datasets && datasets.length > 0) {
           datasets = datasets.map((ds) => ({
@@ -214,11 +214,11 @@ export function updateDatasets() {
             variables: [...ds.variables, ...(userVariables[ds.id] || [])],
           }));
           // Dispatch updated dataset
-          dispatch(_updateDatasets(datasets, entrypoint_dataset_id));
+          dispatch(_updateDatasets(datasets, entrypointDatasetId));
           // Adjust selection state
           const selectedDatasetId =
             getState().controlState.selectedDatasetId ||
-            entrypoint_dataset_id ||
+            entrypointDatasetId ||
             datasets[0].id;
           dispatch(
             selectDataset(
@@ -242,9 +242,9 @@ export function updateDatasets() {
 
 export function _updateDatasets(
   datasets: Dataset[],
-  entrypoint_dataset_id?: string,
+  entrypointDatasetId?: string,
 ): UpdateDatasets {
-  return { type: UPDATE_DATASETS, datasets, entrypoint_dataset_id };
+  return { type: UPDATE_DATASETS, datasets, entrypointDatasetId };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -203,10 +203,10 @@ export function updateDatasets() {
 
     api
       .getDatasets(apiServer.url, getState().userAuthState.accessToken)
-      .then((ds_response: DatasetsResponse) => {
+      .then((datasetsResponse: DatasetsResponse) => {
         // Add user variables from local storage
-        let datasets = ds_response.datasets;
-        const entrypointDatasetId = ds_response.entrypointDatasetId;
+        let datasets = datasetsResponse.datasets;
+        const entrypointDatasetId = datasetsResponse.entrypointDatasetId;
         const userVariables = loadUserVariables();
         if (datasets && datasets.length > 0) {
           datasets = datasets.map((ds) => ({

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -208,14 +208,14 @@ export function updateDatasets() {
         let datasets = ds_response.datasets;
         const entrypoint_dataset_id = ds_response.entrypoint_dataset_id;
         const userVariables = loadUserVariables();
-        datasets = datasets.map((ds) => ({
-          ...ds,
-          variables: [...ds.variables, ...(userVariables[ds.id] || [])],
-        }));
-        // Dispatch updated dataset
-        dispatch(_updateDatasets(datasets, entrypoint_dataset_id));
-        // Adjust selection state
-        if (datasets.length > 0) {
+        if (datasets && datasets.length > 0) {
+          datasets = datasets.map((ds) => ({
+            ...ds,
+            variables: [...ds.variables, ...(userVariables[ds.id] || [])],
+          }));
+          // Dispatch updated dataset
+          dispatch(_updateDatasets(datasets, entrypoint_dataset_id));
+          // Adjust selection state
           const selectedDatasetId =
             getState().controlState.selectedDatasetId ||
             entrypoint_dataset_id ||
@@ -242,7 +242,7 @@ export function updateDatasets() {
 
 export function _updateDatasets(
   datasets: Dataset[],
-  entrypoint_dataset_id: string,
+  entrypoint_dataset_id?: string,
 ): UpdateDatasets {
   return { type: UPDATE_DATASETS, datasets, entrypoint_dataset_id };
 }

--- a/src/api/getDatasets.ts
+++ b/src/api/getDatasets.ts
@@ -27,13 +27,13 @@ export function getDatasets(
 }
 
 function adjustTimeDimensionsForDatasets(
-  raw_ds_response: RawDatasetsResponse,
+  rawDatasetsResponse: RawDatasetsResponse,
 ): DatasetsResponse {
   return {
-    datasets: (raw_ds_response.datasets || []).map(
+    datasets: (rawDatasetsResponse.datasets || []).map(
       adjustTimeDimensionsForDataset,
     ),
-    entrypointDatasetId: raw_ds_response.entrypointDatasetId,
+    entrypointDatasetId: rawDatasetsResponse.entrypointDatasetId,
   };
 }
 

--- a/src/api/getDatasets.ts
+++ b/src/api/getDatasets.ts
@@ -7,21 +7,39 @@
 import { Dataset, Dimension, TimeDimension } from "@/model/dataset";
 import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
 
-interface RawDatasets {
+interface RawDatasetsResponse {
   datasets?: Dataset[];
+  entrypoint_dataset_id?: string;
+}
+
+interface RawDatasetsResponse {
+  datasets?: Dataset[];
+  entrypoint_dataset_id?: string;
+}
+
+export interface DatasetsResponse {
+  datasets?: Dataset[];
+  entrypoint_dataset_id?: string;
 }
 
 export function getDatasets(
   apiServerUrl: string,
   accessToken: string | null,
-): Promise<Dataset[]> {
+): Promise<RawDatasetsResponse> {
   const url = makeRequestUrl(`${apiServerUrl}/datasets`, [["details", "1"]]);
   const init = makeRequestInit(accessToken);
   return callJsonApi(url, init, adjustTimeDimensionsForDatasets);
 }
 
-function adjustTimeDimensionsForDatasets(datasets: RawDatasets): Dataset[] {
-  return (datasets.datasets || []).map(adjustTimeDimensionsForDataset);
+function adjustTimeDimensionsForDatasets(
+  raw_ds_response: RawDatasetsResponse,
+): DatasetsResponse {
+  return {
+    datasets: (raw_ds_response.datasets || []).map(
+      adjustTimeDimensionsForDataset,
+    ),
+    entrypoint_dataset_id: raw_ds_response.entrypoint_dataset_id,
+  };
 }
 
 function adjustTimeDimensionsForDataset(dataset: Dataset): Dataset {

--- a/src/api/getDatasets.ts
+++ b/src/api/getDatasets.ts
@@ -9,17 +9,12 @@ import { callJsonApi, makeRequestInit, makeRequestUrl } from "./callApi";
 
 interface RawDatasetsResponse {
   datasets?: Dataset[];
-  entrypoint_dataset_id?: string;
-}
-
-interface RawDatasetsResponse {
-  datasets?: Dataset[];
-  entrypoint_dataset_id?: string;
+  entrypointDatasetId?: string;
 }
 
 export interface DatasetsResponse {
   datasets?: Dataset[];
-  entrypoint_dataset_id?: string;
+  entrypointDatasetId?: string;
 }
 
 export function getDatasets(
@@ -38,7 +33,7 @@ function adjustTimeDimensionsForDatasets(
     datasets: (raw_ds_response.datasets || []).map(
       adjustTimeDimensionsForDataset,
     ),
-    entrypoint_dataset_id: raw_ds_response.entrypoint_dataset_id,
+    entrypointDatasetId: raw_ds_response.entrypointDatasetId,
   };
 }
 

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -38,16 +38,28 @@ export default function DatasetSelect({
 }: DatasetSelectProps) {
   const sortedDatasets = useMemo(() => {
     return datasets.sort((dataset1: Dataset, dataset2: Dataset) => {
+      console.log(dataset1.sortValue, dataset2.sortValue);
       const groupTitle1 = dataset1.groupTitle || "zzz";
       const groupTitle2 = dataset2.groupTitle || "zzz";
       const delta = groupTitle1.localeCompare(groupTitle2);
       if (delta !== 0) {
         return delta;
       }
-      if (dataset1.sortValue && dataset2.sortValue) {
-        return dataset1.sortValue - dataset2.sortValue;
+      const sortValue1 = dataset1.sortValue;
+      const sortValue2 = dataset2.sortValue;
+
+      // Handles when both sortValue are available
+      if (sortValue1 !== undefined && sortValue2 !== undefined) {
+        return sortValue1 - sortValue2;
       }
-      return dataset1.title.localeCompare(dataset2.title);
+
+      // Handles when no sortValue is available
+      if (sortValue1 === undefined && sortValue2 === undefined) {
+        return dataset1.title.localeCompare(dataset2.title);
+      }
+
+      // Handles when only one sortValue is available
+      return sortValue1 !== undefined ? -1 : 1;
     });
   }, [datasets]);
 

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -44,6 +44,9 @@ export default function DatasetSelect({
       if (delta !== 0) {
         return delta;
       }
+      if (dataset1.sortValue && dataset2.sortValue) {
+        return dataset1.sortValue - dataset2.sortValue;
+      }
       return dataset1.title.localeCompare(dataset2.title);
     });
   }, [datasets]);

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -38,7 +38,6 @@ export default function DatasetSelect({
 }: DatasetSelectProps) {
   const sortedDatasets = useMemo(() => {
     return datasets.sort((dataset1: Dataset, dataset2: Dataset) => {
-      console.log(dataset1.sortValue, dataset2.sortValue);
       const groupTitle1 = dataset1.groupTitle || "zzz";
       const groupTitle2 = dataset2.groupTitle || "zzz";
       const delta = groupTitle1.localeCompare(groupTitle2);

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -47,6 +47,7 @@ export interface Dataset {
   title: string;
   description?: string;
   groupTitle?: string;
+  sortValue?: number;
   tags?: string[];
   bbox: [number, number, number, number];
   geometry: {

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -122,7 +122,17 @@ export function controlReducer(
       } else {
         selectedDatasetId = null;
         selectedVariableName = null;
-        selectedDataset = action.datasets.length ? action.datasets[0] : null;
+        if (action.entrypoint_dataset_id) {
+          selectedDataset = findDataset(
+            action.datasets,
+            action.entrypoint_dataset_id,
+          );
+        }
+        selectedDataset = action.datasets.length
+          ? selectedDataset
+            ? selectedDataset
+            : action.datasets[0]
+          : null;
         if (selectedDataset) {
           selectedDatasetId = selectedDataset.id;
           if (selectedDataset.variables.length > 0) {

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -122,10 +122,10 @@ export function controlReducer(
       } else {
         selectedDatasetId = null;
         selectedVariableName = null;
-        if (action.entrypoint_dataset_id) {
+        if (action.entrypointDatasetId) {
           selectedDataset = findDataset(
             action.datasets,
-            action.entrypoint_dataset_id,
+            action.entrypointDatasetId,
           );
         }
         selectedDataset = action.datasets.length


### PR DESCRIPTION
This PR does the following

- respects the new addition of attribute `EntrypointDatasetId` to the xcube-server config that allows the users to choose freely which dataset they want to show on xcube-viewer upon loading.
- use `sortValue` from the config provided to sort the datasets within a group that are shown in the dataset selector. The sorting happens as follows when comparing two elements:
   - if both have sortValue, sort them
   - if none of them have sortValue, fallback to sorting by title
   - if one of them has sortValue, prefer the one with sortValue.

This provides the user with ability to sort only subset of datasets in a group if preferred to.

Issue: https://github.com/xcube-dev/xcube/issues/1135
See also: https://github.com/xcube-dev/xcube/pull/1147