### PR TITLE
Add new State properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   for sorting datasets within groups if provided.
   See https://github.com/xcube-dev/xcube/issues/1135.
 
+### Other Changes
+
+* Added `selectedDatasetTitle` and `selectedDataset2Title` to the list
+  of available state properties.
+  See https://github.com/xcube-dev/xcube/issues/1134
 
 ## Changes in version 1.5.0
 

--- a/src/connected/ColorBarLegend2.tsx
+++ b/src/connected/ColorBarLegend2.tsx
@@ -9,7 +9,7 @@ import { connect } from "react-redux";
 import { AppState } from "@/states/appState";
 import {
   colorBarsSelector,
-  selectedDatasetTitle2Selector,
+  selectedDataset2TitleSelector,
   selectedVariable2ColorBarMinMaxSelector,
   selectedVariable2ColorBarNameSelector,
   selectedVariable2ColorBarNormSelector,
@@ -33,7 +33,7 @@ import _ColorBarLegend from "@/components/ColorBarLegend";
 const mapStateToProps = (state: AppState) => {
   const splitPos = state.controlState.variableSplitPos;
   return {
-    datasetTitle: selectedDatasetTitle2Selector(state),
+    datasetTitle: selectedDataset2TitleSelector(state),
     variableName: splitPos ? selectedVariable2NameSelector(state) : null,
     variableTitle: selectedVariable2TitleSelector(state),
     variableUnits: selectedVariable2UnitsSelector(state),

--- a/src/ext/store.ts
+++ b/src/ext/store.ts
@@ -54,7 +54,7 @@ export const derivedStateProperties: Record<string, DerivedStateProperty> = {
   selectedDataset2Title: {
     type: "str | None",
     description: "The title of the dataset that contains the pinned variable.",
-    selector: selectedDatasetTitle2Selector,
+    selector: selectedDataset2TitleSelector,
   },
   selectedVariable2Name: {
     type: "str | None",

--- a/src/ext/store.ts
+++ b/src/ext/store.ts
@@ -18,7 +18,7 @@ import {
   selectedVariable2NameSelector,
   selectedVariableNameSelector,
   selectedDatasetTitleSelector,
-  selectedDatasetTitle2Selector,
+  selectedDataset2TitleSelector,
 } from "@/selectors/controlSelectors";
 import { getPaletteMode } from "@/states/controlState";
 

--- a/src/ext/store.ts
+++ b/src/ext/store.ts
@@ -17,6 +17,8 @@ import {
   selectedDatasetAndUserPlaceGroupsSelector,
   selectedVariable2NameSelector,
   selectedVariableNameSelector,
+  selectedDatasetTitleSelector,
+  selectedDatasetTitle2Selector,
 } from "@/selectors/controlSelectors";
 import { getPaletteMode } from "@/states/controlState";
 
@@ -32,6 +34,11 @@ export const derivedStateProperties: Record<string, DerivedStateProperty> = {
     description: "The identifier of the currently selected dataset.",
     selector: selectedDatasetIdSelector,
   },
+  selectedDatasetTitle: {
+    type: "str | None",
+    description: "The title of the currently selected dataset.",
+    selector: selectedDatasetTitleSelector,
+  },
   selectedVariableName: {
     type: "str | None",
     description:
@@ -43,6 +50,11 @@ export const derivedStateProperties: Record<string, DerivedStateProperty> = {
     description:
       "The identifier of the dataset that contains the pinned variable.",
     selector: selectedDataset2IdSelector,
+  },
+  selectedDataset2Title: {
+    type: "str | None",
+    description: "The title of the dataset that contains the pinned variable.",
+    selector: selectedDatasetTitle2Selector,
   },
   selectedVariable2Name: {
     type: "str | None",
@@ -57,14 +69,12 @@ export const derivedStateProperties: Record<string, DerivedStateProperty> = {
   },
   selectedPlaceId: {
     type: "str | None",
-    description:
-      "The identifier of the currently selected place.",
+    description: "The identifier of the currently selected place.",
     selector: selectedPlaceIdSelector,
   },
   selectedPlaceGroup: {
     type: "list[dict[str, Any]]",
-    description:
-      "The list of dataset place group and user place groups.",
+    description: "The list of dataset place group and user place groups.",
     selector: selectedDatasetAndUserPlaceGroupsSelector,
   },
   selectedTimeLabel: {

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -190,7 +190,7 @@ export const selectedDatasetTitleSelector = createSelector(
   getDatasetTitle,
 );
 
-export const selectedDatasetTitle2Selector = createSelector(
+export const selectedDataset2TitleSelector = createSelector(
   selectedDataset2Selector,
   getDatasetTitle,
 );


### PR DESCRIPTION
This PR addresses a part of https://github.com/xcube-dev/xcube/issues/1134 by exposing two new State properties `selectedDatasetTitle` and `selectedDataset2Title`.