### PR TITLE
Fixed rendering metadata attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,21 @@
 
 ### Improvements
 
-* The viewer application now respects the server-configured initial dataset.
-   See https://github.com/xcube-dev/xcube/issues/1135.
+* Now using an entrypoint dataset that is initially shown 
+  if none has been previously selected.
+  See https://github.com/xcube-dev/xcube/issues/1135.
 
 * Updated the dataset selector to use `sortValue` from the server configuration 
   for sorting datasets within groups if provided.
   See https://github.com/xcube-dev/xcube/issues/1135.
 
+* Added a type column to the metadata attribute tables displayed 
+  in the "details" panel when in list mode.
+
+# Fixes
+
+* Fixed application crash caused by metadata attributes that are (JSON) 
+  objects. Now attributes values of any type are rendered.
 
 ## Changes in version 1.5.0
 

--- a/src/components/InfoPanel/DatasetInfoCard.tsx
+++ b/src/components/InfoPanel/DatasetInfoCard.tsx
@@ -61,6 +61,7 @@ const DatasetInfoCard: React.FC<DatasetInfoContentProps> = ({
             name,
             dataset.attrs[name],
           ])}
+          types
         />
       </InfoCardContent>
     );

--- a/src/components/InfoPanel/PlaceInfoCard.tsx
+++ b/src/components/InfoPanel/PlaceInfoCard.tsx
@@ -50,7 +50,7 @@ const PlaceInfoCard: React.FC<PlaceInfoContentProps> = ({
       );
       content = (
         <InfoCardContent>
-          <KeyValueContent data={data} />
+          <KeyValueContent data={data} types />
         </InfoCardContent>
       );
     } else {

--- a/src/components/InfoPanel/VariableInfoCard.tsx
+++ b/src/components/InfoPanel/VariableInfoCard.tsx
@@ -74,6 +74,7 @@ const VariableInfoCard: React.FC<VariableInfoContentProps> = ({
             name,
             variable.attrs[name],
           ])}
+          types
         />
       </InfoCardContent>
     );

--- a/src/components/InfoPanel/common/KeyValueContent.tsx
+++ b/src/components/InfoPanel/common/KeyValueContent.tsx
@@ -14,6 +14,7 @@ import TableRow from "@mui/material/TableRow";
 
 import { makeStyles } from "@/util/styles";
 import { commonSx } from "./styles";
+import { getRenderedMetadataValue } from "./utils";
 
 const styles = makeStyles({
   keyValueTableContainer: (theme) => ({
@@ -25,33 +26,36 @@ export type KeyValue = [string, React.ReactNode];
 
 interface KeyValueContentProps {
   data: KeyValue[];
+  types?: boolean;
 }
 
-const KeyValueContent: React.FC<KeyValueContentProps> = ({ data }) => {
+const KeyValueContent: React.FC<KeyValueContentProps> = ({ data, types }) => {
   return (
     <TableContainer sx={styles.keyValueTableContainer}>
       <Table sx={commonSx.table} size="small">
         <TableBody>
           {data.map((kv, index) => {
             const [key, value] = kv;
-            let renderedValue = value;
-            // noinspection HttpUrlsUsage
-            if (
-              typeof value === "string" &&
-              (value.startsWith("http://") || value.startsWith("https://"))
-            ) {
-              renderedValue = (
-                <Link href={value} target="_blank" rel="noreferrer">
-                  {value}
-                </Link>
-              );
-            } else if (Array.isArray(value)) {
-              renderedValue = "[" + value.map((v) => v + "").join(", ") + "]";
-            }
+            const renderedValue = getRenderedMetadataValue(value);
+            const isLink =
+              typeof value === "string" && renderedValue.startsWith("https://");
             return (
               <TableRow key={index}>
                 <TableCell>{key}</TableCell>
-                <TableCell align="right">{renderedValue}</TableCell>
+                {types && (
+                  <TableCell>
+                    {Array.isArray(value) ? "array" : typeof value}
+                  </TableCell>
+                )}
+                <TableCell align="right">
+                  {isLink ? (
+                    <Link href={renderedValue} target="_blank" rel="noreferrer">
+                      {renderedValue}
+                    </Link>
+                  ) : (
+                    renderedValue
+                  )}
+                </TableCell>
               </TableRow>
             );
           })}

--- a/src/components/InfoPanel/common/utils.ts
+++ b/src/components/InfoPanel/common/utils.ts
@@ -94,3 +94,13 @@ function splitExt(name: string): [string, string] {
     return [name, ""];
   }
 }
+
+export function getRenderedMetadataValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  } else if (typeof value === "object") {
+    return JSON.stringify(value);
+  } else {
+    return `${value}`;
+  }
+}


### PR DESCRIPTION
In this PR:

* Fixed application crash caused by metadata attributes that are (JSON) objects. Now attributes values of any type are rendered.
* Added a type column to the metadata attribute tables displayed in the "details" panel when in list mode.

