### PR TITLE
Fix: Color maps are now available in the shared state

### DIFF
--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -842,7 +842,6 @@ export function _configureServers(
 export function syncWithServer(store: Store, init: boolean = false) {
   return (dispatch: Dispatch) => {
     dispatch(updateServerInfo() as unknown as Action);
-    dispatch(updateDatasets() as unknown as Action);
     dispatch(updateExpressionCapabilities() as unknown as Action);
     dispatch(updateColorBars() as unknown as Action);
     dispatch(initializeExtensions(store) as unknown as Action);
@@ -850,6 +849,8 @@ export function syncWithServer(store: Store, init: boolean = false) {
     const stateKey = appParams.get("stateKey");
     if (stateKey && init) {
       dispatch(restorePersistedState(store, stateKey) as unknown as Action);
+    } else {
+      dispatch(updateDatasets() as unknown as Action);
     }
   };
 }

--- a/src/states/persistedState.ts
+++ b/src/states/persistedState.ts
@@ -16,6 +16,7 @@ const dataStateProps: readonly (keyof DataState)[] = [
   "userPlaceGroups",
   "timeSeriesGroups",
   "statistics",
+  "datasets",
 ];
 
 const controlStateProps: readonly (keyof ControlState)[] = [


### PR DESCRIPTION
This PR adds the color maps of different variables as selected by the user to the shared state when the current state of the viewer is shared.
Closes: #465