### PR TITLE
None-units units no longer shown in the color legend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,17 @@
 * Added a type column to the metadata attribute tables displayed 
   in the "details" panel when in list mode.
 
+* Variable units are no longer shown in the color legend
+  if the units are either missing in the variable metadata or
+  if it is a no-unit value like `-`, `1`, or an empty string. (#511)
+
 # Fixes
+
+* Assigned color bars are now preserved when sharing the viewer's
+  current state. (#465)
 
 * Fixed application crash caused by metadata attributes that are (JSON) 
   objects. Now attributes values of any type are rendered.
-
-* Colormaps are now preserved when sharing the viewer's current state. (#465)
 
 * Parameter `allow3D` in the viewer branding configuration now hides the  
   `Volume` tab in the side panel when set to `false`. Default is `true`.

--- a/src/components/ColorBarLegend/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend/ColorBarLegend.tsx
@@ -111,16 +111,19 @@ export default function ColorBarLegend(
     return null;
   }
 
-  const variableTitleWithUnits =
-    variableColorBar.type === "categorical"
+  const effectiveVariableTitle =
+    variableColorBar.type === "categorical" ||
+    !variableUnits ||
+    variableUnits === "1" ||
+    variableUnits === "-"
       ? variableTitle || variableName
-      : `${variableTitle || variableName} (${variableUnits || "-"})`;
+      : `${variableTitle || variableName} (${variableUnits})`;
 
   return (
     <Box sx={styles.container} style={style} ref={colorBarSelectAnchorRef}>
       <Box sx={styles.header}>
         <Typography sx={styles.title} variant="subtitle1" color="textPrimary">
-          {variableTitleWithUnits}
+          {effectiveVariableTitle}
         </Typography>
         {datasetTitle && (
           <Typography


### PR DESCRIPTION
Variable units are no longer shown in the color legend if the units are either missing in the variable metadata or if it is a no-unit value like `-`, `1`, or an empty string. 

Closes #511