### PR TITLE
Enable dataset group sorting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,12 @@
   if the units are either missing in the variable metadata or
   if it is a no-unit value like `-`, `1`, or an empty string. (#511)
 
+* Dataset groups in the dataset selector are now sorted according to the 
+  `groupOrder` defined in the server-side configuration.
+
+* Added tooltips to dataset group titles in the selector, displaying the 
+  `groupDescription` provided by the server.
+
 # Fixes
 
 * Assigned color bars are now preserved when sharing the viewer's

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -18,6 +18,7 @@ import ControlBarItem from "./ControlBarItem";
 import { ReactElement, useMemo } from "react";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import { Tooltip } from "@mui/material";
 
 interface DatasetSelectProps extends WithLocale {
   selectedDatasetId: string | null;
@@ -38,6 +39,13 @@ export default function DatasetSelect({
 }: DatasetSelectProps) {
   const sortedDatasets = useMemo(() => {
     return datasets.sort((dataset1: Dataset, dataset2: Dataset) => {
+      const groupOrder1 = dataset1.groupOrder ?? Infinity;
+      const groupOrder2 = dataset2.groupOrder ?? Infinity;
+
+      if (groupOrder1 !== groupOrder2) {
+        return groupOrder1 - groupOrder2;
+      }
+
       const groupTitle1 = dataset1.groupTitle || "zzz";
       const groupTitle2 = dataset2.groupTitle || "zzz";
       const delta = groupTitle1.localeCompare(groupTitle2);
@@ -83,13 +91,17 @@ export default function DatasetSelect({
   sortedDatasets.forEach((dataset) => {
     if (hasGroups) {
       const groupTitle = dataset.groupTitle || i18n.get("Others");
+      const groupDescription =
+        dataset.groupDescription || i18n.get("No" + " Description provided");
       if (groupTitle !== lastGroupTitle) {
         items.push(
-          <Divider key={groupTitle}>
-            <Typography fontSize="small" color="text.secondary">
-              {groupTitle}
-            </Typography>
-          </Divider>,
+          <Tooltip arrow title={groupDescription}>
+            <Divider key={groupTitle}>
+              <Typography fontSize="small" color="text.secondary">
+                {groupTitle}
+              </Typography>
+            </Divider>
+          </Tooltip>,
         );
       }
       lastGroupTitle = groupTitle;

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -47,6 +47,9 @@ export interface Dataset {
   title: string;
   description?: string;
   groupTitle?: string;
+  groupId?: string;
+  groupOrder?: number;
+  groupDescription?: string;
   sortValue?: number;
   tags?: string[];
   bbox: [number, number, number, number];


### PR DESCRIPTION
This PR does the following:

- Implements dataset groups sorting.
- Adds a tooltip which is displayed when the user hovers over the group title in the dataset selector.

If the user has used `DatasetGroups` in the server side, it will sort those groups by the order provided, if not, it will fallback to alphabetical sorting for those without `GroupId`'s.