### PR TITLE
Releasing 1.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Changes in version 1.6.1-dev.0
+## Changes in version 1.6.1
 
 * Slightly updated default logo image (to have a background and hence can be 
   used for light and dark theme mode).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcube-viewer",
-  "version": "1.6.1-dev.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcube-viewer",
-      "version": "1.6.1-dev.0",
+      "version": "1.6.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.17.0",
         "@codemirror/lang-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "1.6.1-dev.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -5,6 +5,6 @@
  */
 
 // Important: use semantic versioning (https://semver.org/)
-const version = "1.6.1-dev.0";
+const version = "1.6.1";
 
 export default version;


### PR DESCRIPTION
## Changes in version 1.6.1

* Slightly updated default logo image (to have a background and hence can be 
  used for light and dark theme mode).

*  Pinned `vega-lite` and `vega` versions to ensure compatibility and prevent peer
   dependency conflicts during installation (#531).