### PR TITLE
 Statistics image export

### DIFF
--- a/src/actions/mapActions.tsx
+++ b/src/actions/mapActions.tsx
@@ -83,11 +83,3 @@ export function getMapElement(): RefObject<HTMLDivElement | null> {
     : null;
   return { current: targetElement as HTMLDivElement | null };
 }
-
-export function getHiddenElements(element: HTMLElement | null) {
-  if (!element) return [];
-  return [
-    element.querySelector(".ol-unselectable.ol-control.MuiBox-root.css-0"),
-    element.querySelector(".ol-zoom.ol-unselectable.ol-control"),
-  ].filter(Boolean) as HTMLElement[];
-}

--- a/src/actions/otherActions.tsx
+++ b/src/actions/otherActions.tsx
@@ -52,10 +52,8 @@ export function getHiddenElements(element: HTMLElement | null) {
     // Map Elements
     element.querySelector(".ol-unselectable.ol-control.MuiBox-root.css-0"),
     element.querySelector(".ol-zoom.ol-unselectable.ol-control"),
-    // Statistics Elements
-    element.querySelector(".data-hover-invisible-box"),
-    // element.querySelector(".css-yld2sw"),
-    // element.querySelector(".css-kzq9y8"),
+    // Statistics-Panel Elements
+    element.querySelector("#statistics-row-buttons"),
   ].filter(Boolean) as HTMLElement[];
 }
 

--- a/src/actions/otherActions.tsx
+++ b/src/actions/otherActions.tsx
@@ -45,6 +45,20 @@ function restoreMapView(mapState: PersistedMapState) {
   }
 }
 
+export function getHiddenElements(element: HTMLElement | null) {
+  if (!element) return [];
+
+  return [
+    // Map Elements
+    element.querySelector(".ol-unselectable.ol-control.MuiBox-root.css-0"),
+    element.querySelector(".ol-zoom.ol-unselectable.ol-control"),
+    // Statistics Elements
+    element.querySelector(".data-hover-invisible-box"),
+    // element.querySelector(".css-yld2sw"),
+    // element.querySelector(".css-kzq9y8"),
+  ].filter(Boolean) as HTMLElement[];
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 export type OtherAction = ApplyPersistedState;

--- a/src/components/HoverVisibleBox.tsx
+++ b/src/components/HoverVisibleBox.tsx
@@ -20,6 +20,7 @@ const HoverVisibleBox = ({
 }: HoverVisibleBoxProps) => {
   return (
     <Box
+      id="data-hover-invisible-box"
       {...props}
       sx={{
         ...sx,

--- a/src/components/MapSnapshotButton.tsx
+++ b/src/components/MapSnapshotButton.tsx
@@ -11,7 +11,8 @@ import MapButton from "@/components/Viewer/MapButton";
 import i18n from "@/i18n";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import { useCopySnapshotToClipboard } from "@/hooks/useCopySnapshotToClipboard";
-import { getMapElement, getHiddenElements } from "@/actions/mapActions";
+import { getMapElement } from "@/actions/mapActions";
+import { getHiddenElements } from "@/actions/otherActions";
 
 interface MapSnapshotButtonProps extends WithLocale {
   postMessage: (messageType: MessageType, messageText: string | Error) => void;

--- a/src/components/SnapshotButton.tsx
+++ b/src/components/SnapshotButton.tsx
@@ -11,6 +11,7 @@ import i18n from "@/i18n";
 import { WithLocale } from "@/util/lang";
 import { ExportResolution } from "@/states/controlState";
 import { MessageType } from "@/states/messageLogState";
+import { getHiddenElements } from "@/actions/otherActions";
 import ToolButton from "@/components/ToolButton";
 import { useCopySnapshotToClipboard } from "@/hooks/useCopySnapshotToClipboard";
 
@@ -25,9 +26,12 @@ export default function SnapshotButton({
   postMessage,
   exportResolution,
 }: SnapshotButtonProps) {
+  const hiddenElements = (root: HTMLElement) => getHiddenElements(root);
+
   const exportOptions = {
     postMessage,
     exportResolution,
+    hiddenElements,
   };
 
   const { onSnapshotClick } = useCopySnapshotToClipboard(

--- a/src/components/StatisticsPanel/StatisticsRow.tsx
+++ b/src/components/StatisticsPanel/StatisticsRow.tsx
@@ -47,7 +47,7 @@ interface StatisticsRowProps extends WithLocale {
 }
 
 function Missing({ phrase }: { phrase: string }) {
-  return <span style={{ color: "red" }}>{`<${i18n.get(phrase)}?>`}</span>;
+  return <span style={{ color: "red" }}>{`<${i18n.get(phrase)} ?>`}</span>;
 }
 
 export default function StatisticsRow({
@@ -74,14 +74,17 @@ export default function StatisticsRow({
     <Missing phrase="Time" />
   ) : null;
   const placeLabel = placeInfo ? placeInfo.label : <Missing phrase="Place" />;
+
   return (
     <Box sx={styles.container} ref={containerRef}>
       <Box sx={styles.header}>
-        <Typography fontSize="small">
+        <Typography fontSize="small" variant="inherit" component="span">
           {datasetLabel} / {variableLabel}
           {timeLabel && `, ${timeLabel}`}, {placeLabel}
         </Typography>
-        <Box sx={styles.actions}>{actions}</Box>
+        <Box id="statistics-row-buttons" sx={styles.actions}>
+          {actions}
+        </Box>
       </Box>
       {body && <Box sx={styles.body}>{body}</Box>}
     </Box>

--- a/src/util/export.ts
+++ b/src/util/export.ts
@@ -61,7 +61,8 @@ async function _exportElement(
   }
 
   hiddenElements.forEach((el) => {
-    el.style.visibility = "hidden";
+    // el.style.visibility = "hidden";
+    el.style.opacity = "0";
   });
 
   const dpi = options.exportResolution;
@@ -102,6 +103,7 @@ async function _exportElement(
   await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
 
   hiddenElements.forEach((el) => {
-    el.style.visibility = "visible";
+    //  el.style.visibility = "visible";
+    el.style.opacity = "1";
   });
 }

--- a/src/util/export.ts
+++ b/src/util/export.ts
@@ -61,7 +61,6 @@ async function _exportElement(
   }
 
   hiddenElements.forEach((el) => {
-    // el.style.visibility = "hidden";
     el.style.opacity = "0";
   });
 
@@ -103,7 +102,6 @@ async function _exportElement(
   await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
 
   hiddenElements.forEach((el) => {
-    //  el.style.visibility = "visible";
     el.style.opacity = "1";
   });
 }


### PR DESCRIPTION
This PR introduces the following improvements when exporting the image of a Statistics chart:
- hiding the buttons above the chart
- preventing a linebreak for the PlaceLabel in the text above the chart