### PR TITLE
Enable customization of `Login` button

### DIFF
--- a/src/components/UserControl.tsx
+++ b/src/components/UserControl.tsx
@@ -19,6 +19,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
+import Tooltip from "@mui/material/Tooltip";
 import PersonIcon from "@mui/icons-material/Person";
 
 import i18n from "@/i18n";
@@ -48,9 +49,10 @@ const styles = makeStyles({
     marginTop: -12,
     marginLeft: -12,
   },
-  iconButton: {
-    padding: 0,
-  },
+  iconButton: (theme) => ({
+    marginLeft: theme.spacing(2),
+    ...Config.instance.branding.headerIconStyle,
+  }),
 });
 
 const StyledContainerDiv = styled("div")(({ theme }: { theme: Theme }) => ({
@@ -205,12 +207,15 @@ const UserControlContent: React.FC<UserControlProps> = ({
     );
   } else {
     let userButton = (
-      <IconButton
-        onClick={auth.isLoading ? undefined : handleSignInButtonClicked}
-        size="small"
-      >
-        <PersonIcon />
-      </IconButton>
+      <Tooltip arrow title={i18n.get("User Profile")}>
+        <IconButton
+          onClick={auth.isLoading ? undefined : handleSignInButtonClicked}
+          size="small"
+          sx={styles.iconButton}
+        >
+          <PersonIcon />
+        </IconButton>
+      </Tooltip>
     );
     if (auth.isLoading) {
       userButton = (

--- a/src/components/UserControl.tsx
+++ b/src/components/UserControl.tsx
@@ -7,7 +7,7 @@
 import * as React from "react";
 import { useAuth } from "react-oidc-context";
 import { makeStyles } from "@/util/styles";
-import { Theme, styled } from "@mui/system";
+import { styled } from "@mui/system";
 import { deepOrange } from "@mui/material/colors";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
@@ -55,10 +55,9 @@ const styles = makeStyles({
   }),
 });
 
-const StyledContainerDiv = styled("div")(({ theme }: { theme: Theme }) => ({
-  margin: theme.spacing(1),
+const StyledContainerDiv = styled("div")({
   position: "relative",
-}));
+});
 
 interface UserControlProps extends WithLocale {
   updateAccessToken: (accessToken: string | null) => void;


### PR DESCRIPTION
This PR:
- enables styling of the `Login` button, so that the button's appearance can be determined in the xcube Viewer configurations.
- adds tooltip to `Login` button.
- prevents the movement of the `Login` button to the left when logging in/logged in.

![grafik](https://github.com/user-attachments/assets/0104f749-0a9d-464a-80ee-24eb012dddda)


This PR closes #534. 


