### PR TITLE
Enable custom permalink message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Changes in version 1.6.2 (in development) 
 
+### Improvements
+
+*  Enabled configuration of the permalink message via `config.json`, 
+   with optional display of the expiration duration in days. (#500)
+
 ### Fixes
 
 *  Applied workaround for a bug in `html-to-image` libary that causes an 

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -145,7 +145,7 @@ export function shareStatePermalink() {
 
           const expiration = Config.instance.branding.permalinkExpirationDays;
           const message =
-            expiration !== undefined
+            typeof expiration === "number"
               ? i18n.get(
                   "Permalink copied to clipboard (expires in ${expiration} days)",
                   { expiration },

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -11,7 +11,7 @@ import { saveAs } from "file-saver";
 
 import * as api from "@/api";
 import i18n from "@/i18n";
-import { appParams } from "@/config";
+import { appParams, Config } from "@/config";
 import { ApiServerConfig, ApiServerInfo } from "@/model/apiServer";
 import { ColorBar, ColorBars } from "@/model/colorBar";
 import { Dataset, getDatasetUserVariables } from "@/model/dataset";
@@ -142,10 +142,18 @@ export function shareStatePermalink() {
           const location = window.location;
           const viewerUrl = location.origin + location.pathname;
           const stateUrl = `${viewerUrl}?stateKey=${stateKey}`;
+
+          const expiration = Config.instance.branding.permalinkExpirationDays;
+          const message =
+            expiration !== undefined
+              ? i18n.get(
+                  "Permalink copied to clipboard (expires in ${expiration} days)",
+                  { expiration },
+                )
+              : i18n.get("Permalink copied to clipboard");
+
           navigator.clipboard.writeText(stateUrl).then(() => {
-            dispatch(
-              postMessage("success", i18n.get("Permalink copied to clipboard")),
-            );
+            dispatch(postMessage("success", message));
           });
         } else {
           dispatch(

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -28,6 +28,7 @@
     "allowSharing": true,
     "allowUserVariables": true,
     "allowViewModePython": true,
-    "allow3D": true
+    "allow3D": true,
+    "permalinkExpirationDays": 120
   }
 }

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -1341,6 +1341,26 @@
       "se": "Professionell utskriftsupplösning (600 DPI)"
     },
     {
+      "en": "Creating permalink",
+      "de": "Permalink erstellen",
+      "se": "Skapa permalänk"
+    },
+    {
+      "en": "Failed to create permalink",
+      "de": "Permalink konnte nicht erstellt werden",
+      "se": "Skapa permalänk misslyckades"
+    },
+    {
+      "en": "Permalink copied to clipboard",
+      "de": "Permalink in die Zwischenablage kopiert",
+      "se": "Permalink kopieras till klippbordet"
+    },
+     {
+      "en": "Permalink copied to clipboard (expires in ${expiration} days)",
+      "de": "Permalink in die Zwischenablage kopiert (läuft ab in ${expiration} Tagen)",
+      "se": "Permalink kopieras till klippbordet (går ut om ${expiration} dagar)"
+    },
+    {
       "en": "docs/imprint.en.md",
       "de": "docs/imprint.en.md",
       "se": "docs/imprint.en.md"

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -89,6 +89,7 @@ export interface Branding {
   allowViewModePython?: boolean;
   allowUserVariables?: boolean;
   allow3D?: boolean;
+  permalinkExpirationDays?: number;
 }
 
 function setBrandingPaletteColor(


### PR DESCRIPTION
This PR:
- enables a custom permalink message with the information on exiration duration of the link in day in `config.json`s. This customization is optional.
- adds translations to `lang.json`


in `config.json`:
```
"branding": {  
  "permalinkExpirationDays": 300
  }
```

Example:
![grafik](https://github.com/user-attachments/assets/9f558216-c66c-4a85-bb27-9c93be2f1f2a)

This PR closes #500. 