### PR TITLE
Add progress bar to vizualize tile loading progress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@
   Window. If this feature is configured, an `About` window can be opened
   with a button in the header and it will be shown initially while
   data is loading. (#508) 
+  
+* Added a progress bar to the bottom of the map to vizualize the progress
+  of tile loading. (#541)
 
 ## Changes in version 1.6.1
 

--- a/src/components/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-2025 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import ProgressBar from "./ProgressBar";
+
+const meta: Meta = {
+  component: ProgressBar,
+  title: "ProgressBar",
+  parameters: {
+    // Optional parameter to center the component in the Canvas.
+    // More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry:
+  // https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+} satisfies Meta<typeof ProgressBar>;
+
+// noinspection JSUnusedGlobalSymbols
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// noinspection JSUnusedGlobalSymbols
+export const Default: Story = {
+  args: {
+    progress: 75,
+  },
+};

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019-2025 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import React from "react";
+import { Box } from "@mui/material";
+import { Theme } from "@mui/system";
+
+const styles = {
+  wrapper: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    width: "100%",
+    height: "4px",
+    pointerEvents: "none",
+  },
+};
+
+interface ProgressBarProps {
+  progress: number;
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ progress }) => {
+  return (
+    <Box sx={styles.wrapper}>
+      <Box
+        sx={(theme: Theme) => ({
+          height: "100%",
+          backgroundColor: theme.palette.primary.main,
+          transition: " width 300ms ease, opacity 500ms ease",
+          width: `${progress}%`,
+          opacity: progress >= 100 ? 0 : 1,
+        })}
+      />
+    </Box>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -14,7 +14,7 @@ const styles = {
     bottom: 0,
     left: 0,
     width: "100%",
-    height: "4px",
+    height: "5px",
     pointerEvents: "none",
   },
 };
@@ -23,7 +23,9 @@ interface ProgressBarProps {
   progress: number;
 }
 
-const ProgressBar: React.FC<ProgressBarProps> = ({ progress }) => {
+const ProgressBar: React.FC<ProgressBarProps> = ({
+  progress,
+}: ProgressBarProps) => {
   return (
     <Box sx={styles.wrapper}>
       <Box

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -40,8 +40,9 @@ import {
 import { MAP_OBJECTS, MapInteraction } from "@/states/controlState";
 import { newId } from "@/util/id";
 import { GEOGRAPHIC_CRS } from "@/model/proj";
-import UserVectorLayer from "@/components/UserVectorLayer";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import ProgressBar from "@/components/ProgressBar";
+import UserVectorLayer from "@/components/UserVectorLayer";
 import { ScaleLine } from "@/components/ol/control/ScaleLine";
 import { Draw, DrawEvent } from "@/components/ol/interaction/Draw";
 import { Layers } from "@/components/ol/layer/Layers";
@@ -51,6 +52,9 @@ import { View } from "@/components/ol/View";
 import { setFeatureStyle } from "@/components/ol/style";
 import { findMapLayer } from "@/components/ol/util";
 import { isNumber } from "@/util/types";
+
+import TileLayer from "ol/layer/Tile";
+import { Tile as TileSource } from "ol/source";
 
 const SELECTION_LAYER_ID = "selection";
 const SELECTION_LAYER_SOURCE = new OlVectorSource();
@@ -168,6 +172,7 @@ export default function Viewer({
   const [selectedPlaceIdPrev, setSelectedPlaceIdPrev] = useState<string | null>(
     selectedPlaceId || null,
   );
+  const [progress, setProgress] = useState(0);
 
   // If the place selection changed in the UI,
   // synchronize selection in the map.
@@ -259,6 +264,63 @@ export default function Viewer({
       }
     };
   });
+
+  // display progress bar at the bottom of map, when tiles are loading
+  useEffect(() => {
+    if (!map) return;
+
+    let loading = 0;
+    let loaded = 0;
+
+    const updateProgress = () => {
+      const percent = loading > 0 ? (loaded / loading) * 100 : 0;
+      setProgress(Math.min(percent, 100));
+
+      if (percent >= 100 && loading > 0) {
+        loading = 0;
+        loaded = 0;
+        // setProgress(0);
+      }
+    };
+
+    const onTileLoadStart = () => {
+      loading++;
+      updateProgress();
+    };
+
+    const onTileLoadEnd = () => {
+      loaded++;
+      updateProgress();
+    };
+
+    const onTileLoadError = () => {
+      loaded++;
+      updateProgress();
+    };
+
+    const layers = map.getLayers().getArray();
+    const sourcesWithListeners: TileSource[] = [];
+
+    for (const layer of layers) {
+      if (layer instanceof TileLayer) {
+        const source = layer.getSource();
+        if (source) {
+          sourcesWithListeners.push(source);
+          source.on("tileloadstart", onTileLoadStart);
+          source.on("tileloadend", onTileLoadEnd);
+          source.on("tileloaderror", onTileLoadError);
+        }
+      }
+    }
+
+    return () => {
+      for (const source of sourcesWithListeners) {
+        source.un("tileloadstart", onTileLoadStart);
+        source.un("tileloadend", onTileLoadEnd);
+        source.un("tileloaderror", onTileLoadError);
+      }
+    };
+  }, [map]);
 
   const handleMapClick = (event: OlMapBrowserEvent<UIEvent>) => {
     if (mapInteraction === "Select") {
@@ -427,6 +489,7 @@ export default function Viewer({
         {mapControlActions}
         {mapSplitter}
         <ScaleLine bar={false} />
+        <ProgressBar progress={progress} />
       </Map>
     </ErrorBoundary>
   );

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -279,7 +279,6 @@ export default function Viewer({
       if (percent >= 100 && loading > 0) {
         loading = 0;
         loaded = 0;
-        // setProgress(0);
       }
     };
 


### PR DESCRIPTION
This PR:
- adds a progress bar to the bottom of the map that appears while tile loading.


https://github.com/user-attachments/assets/7a8c641d-b0c1-4989-ac10-bd7c819afa3e

