### PR TITLE
Improve usability of User Variables dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,20 @@
 
 ### Improvements
 
-*  Enabled configuration of the permalink message via `config.json`, 
-   with optional display of the expiration duration in days. (#500)
+* Enabled configuration of the permalink message via `config.json`, 
+  with optional display of the expiration duration in days. (#500)
    
-*  Added support for changing image sources in Markdown based on 
-   the selected theme (e.g., light or dark mode). Examples: (#539)
-   ```
-   ![Logo](logo-light.png#light-mode-only)
-   ![Logo](logo-dark.png#dark-mode-only)
-   ```
+* Added support for changing image sources in Markdown based on 
+  the selected theme (e.g., light or dark mode). Examples: (#539)
+  ```
+  ![Logo](logo-light.png#light-mode-only)
+  ![Logo](logo-dark.png#dark-mode-only)
+  ```
+  
+* Restructured User Variables Dialog for adding and editing variables. 
+  Commit and cancel actions are no longer shown in the header, the 
+  bottom-right dialog buttons are now used for these actions. (#546)
+ 
 
 ### Fixes
 

--- a/src/components/UserVariablesDialog/HeaderBar.tsx
+++ b/src/components/UserVariablesDialog/HeaderBar.tsx
@@ -13,7 +13,7 @@ import CalculateIcon from "@mui/icons-material/Calculate";
 interface HeaderBarProps {
   selected: boolean;
   title: ReactNode;
-  actions: ReactNode;
+  actions?: ReactNode;
 }
 
 export default function HeaderBar({

--- a/src/components/UserVariablesDialog/UserVariableEditor.tsx
+++ b/src/components/UserVariablesDialog/UserVariableEditor.tsx
@@ -61,8 +61,8 @@ interface UserVariableEditorProps {
   contextDataset: Dataset;
   expressionCapabilities: ExpressionCapabilities;
   serverUrl: string;
-  canApply: boolean;
-  setCanApply: (canApply: boolean) => void;
+  canCommit: boolean;
+  setCanCommit: (canCommit: boolean) => void;
 }
 
 export default function UserVariableEditor({
@@ -72,8 +72,8 @@ export default function UserVariableEditor({
   contextDataset,
   expressionCapabilities,
   serverUrl,
-  canApply,
-  setCanApply,
+  canCommit,
+  setCanCommit,
 }: UserVariableEditorProps) {
   const [exprPartTypes, setExprPartTypes] = useState(exprPartTypesDefault);
   const [exprFilterAnchorEl, setExprFilterAnchorEl] =
@@ -97,10 +97,10 @@ export default function UserVariableEditor({
   );
   const isExpressionOk = !expressionProblem;
 
-  canApply = isNameOk && isExpressionOk;
+  canCommit = isNameOk && isExpressionOk;
   useEffect(() => {
-    setCanApply(canApply);
-  }, [setCanApply, canApply]);
+    setCanCommit(canCommit);
+  }, [setCanCommit, canCommit]);
 
   const handleInsertPartRef = useRef<null | ((part: string) => void)>(null);
   useEffect(() => {

--- a/src/components/UserVariablesDialog/UserVariableEditor.tsx
+++ b/src/components/UserVariablesDialog/UserVariableEditor.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/model/userVariable";
 import { isIdentifier } from "@/util/identifier";
 import { makeStyles } from "@/util/styles";
-import DoneCancel from "@/components/DoneCancel";
 import ExprPartChip from "@/components/UserVariablesDialog/ExprPartChip";
 import ExprPartFilterMenu from "@/components/UserVariablesDialog/ExprPartFilterMenu";
 import { EditedVariable, exprPartKeys, exprPartTypesDefault } from "./utils";
@@ -57,22 +56,24 @@ const styles = makeStyles({
 
 interface UserVariableEditorProps {
   userVariables: UserVariable[];
-  setUserVariables: (userVariables: UserVariable[]) => void;
   editedVariable: EditedVariable;
   setEditedVariable: (editedVariable: EditedVariable | null) => void;
   contextDataset: Dataset;
   expressionCapabilities: ExpressionCapabilities;
   serverUrl: string;
+  canApply: boolean;
+  setCanApply: (canApply: boolean) => void;
 }
 
 export default function UserVariableEditor({
   userVariables,
-  setUserVariables,
   editedVariable,
   setEditedVariable,
   contextDataset,
   expressionCapabilities,
   serverUrl,
+  canApply,
+  setCanApply,
 }: UserVariableEditorProps) {
   const [exprPartTypes, setExprPartTypes] = useState(exprPartTypesDefault);
   const [exprFilterAnchorEl, setExprFilterAnchorEl] =
@@ -95,7 +96,12 @@ export default function UserVariableEditor({
     null,
   );
   const isExpressionOk = !expressionProblem;
-  const canCommit = isNameOk && isExpressionOk;
+
+  canApply = isNameOk && isExpressionOk;
+  useEffect(() => {
+    setCanApply(canApply);
+  }, [setCanApply, canApply]);
+
   const handleInsertPartRef = useRef<null | ((part: string) => void)>(null);
   useEffect(() => {
     // Debounce expression changes
@@ -116,26 +122,6 @@ export default function UserVariableEditor({
       ...editedVariable,
       variable: { ...editedVariable.variable, [key]: value },
     });
-  };
-
-  const handleDone = () => {
-    if (editedVariable.editMode === "add") {
-      setUserVariables([editedVariable.variable, ...userVariables]);
-    } else {
-      const index = userVariables.findIndex(
-        (v) => v.id === editedVariable.variable.id,
-      );
-      if (index >= 0) {
-        const copy = [...userVariables];
-        copy[index] = editedVariable.variable;
-        setUserVariables(copy);
-      }
-    }
-    setEditedVariable(null);
-  };
-
-  const handleCancel = () => {
-    setEditedVariable(null);
   };
 
   const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -219,14 +205,6 @@ export default function UserVariableEditor({
           editedVariable.editMode === "add"
             ? i18n.get("Add user variable")
             : i18n.get("Edit user variable")
-        }
-        actions={
-          <DoneCancel
-            size={"medium"}
-            onDone={handleDone}
-            doneDisabled={!canCommit}
-            onCancel={handleCancel}
-          />
         }
       />
       <Box sx={styles.content}>

--- a/src/components/UserVariablesDialog/UserVariablesDialog.tsx
+++ b/src/components/UserVariablesDialog/UserVariablesDialog.tsx
@@ -64,6 +64,7 @@ export default function UserVariablesDialog({
   const [editedVariable, setEditedVariable] = useState<EditedVariable | null>(
     null,
   );
+  const [canApply, setCanApply] = useState<boolean>(false);
 
   useEffect(() => {
     setLocalUserVariables(userVariables);
@@ -84,6 +85,28 @@ export default function UserVariablesDialog({
   function handleCancelDialog() {
     setLocalUserVariables(userVariables);
     closeDialog(USER_VARIABLES_DIALOG_ID);
+  }
+
+  function handleCancelFromEditor() {
+    setEditedVariable(null);
+  }
+
+  function handleApplyFromEditor() {
+    if (!editedVariable) return;
+
+    if (editedVariable.editMode === "add") {
+      setLocalUserVariables([editedVariable.variable, ...userVariables]);
+    } else {
+      const index = userVariables.findIndex(
+        (v) => v.id === editedVariable.variable.id,
+      );
+      if (index >= 0) {
+        const copy = [...userVariables];
+        copy[index] = editedVariable.variable;
+        setLocalUserVariables(copy);
+      }
+    }
+    setEditedVariable(null);
   }
 
   return (
@@ -107,12 +130,13 @@ export default function UserVariablesDialog({
         ) : (
           <UserVariableEditor
             userVariables={localUserVariables}
-            setUserVariables={setLocalUserVariables}
             editedVariable={editedVariable}
             setEditedVariable={setEditedVariable}
             contextDataset={selectedDataset}
             expressionCapabilities={expressionCapabilities}
             serverUrl={serverUrl}
+            canApply={canApply}
+            setCanApply={setCanApply}
           />
         )}
       </DialogContent>
@@ -123,17 +147,26 @@ export default function UserVariablesDialog({
             helpUrl={i18n.get("docs/user-variables.en.md")}
           />
         </Box>
-        <Box>
-          <Button onClick={handleCancelDialog}>{i18n.get("Cancel")}</Button>
-          <Button
-            onClick={handleConfirmDialog}
-            disabled={
-              editedVariable !== null || !areUserVariablesOk(localUserVariables)
-            }
-          >
-            {i18n.get("OK")}
-          </Button>
-        </Box>
+        {editedVariable !== null ? (
+          <Box>
+            <Button onClick={handleCancelFromEditor}>
+              {i18n.get("Return")}
+            </Button>
+            <Button onClick={handleApplyFromEditor} disabled={!canApply}>
+              {i18n.get("Apply")}
+            </Button>
+          </Box>
+        ) : (
+          <Box>
+            <Button onClick={handleCancelDialog}>{i18n.get("Cancel")}</Button>
+            <Button
+              onClick={handleConfirmDialog}
+              disabled={!areUserVariablesOk(localUserVariables)}
+            >
+              {i18n.get("OK")}
+            </Button>
+          </Box>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/components/UserVariablesDialog/UserVariablesDialog.tsx
+++ b/src/components/UserVariablesDialog/UserVariablesDialog.tsx
@@ -91,7 +91,7 @@ export default function UserVariablesDialog({
     setEditedVariable(null);
   }
 
-  function handleApplyFromEditor() {
+  function handleCommitFromEditor() {
     if (!editedVariable) return;
 
     if (editedVariable.editMode === "add") {
@@ -152,7 +152,7 @@ export default function UserVariablesDialog({
             <Button onClick={handleCancelFromEditor}>
               {i18n.get("Return")}
             </Button>
-            <Button onClick={handleApplyFromEditor} disabled={!canCommit}>
+            <Button onClick={handleCommitFromEditor} disabled={!canCommit}>
               {i18n.get(editedVariable.editMode == "edit" ? "Apply" : "Add")}
             </Button>
           </Box>

--- a/src/components/UserVariablesDialog/UserVariablesDialog.tsx
+++ b/src/components/UserVariablesDialog/UserVariablesDialog.tsx
@@ -64,7 +64,7 @@ export default function UserVariablesDialog({
   const [editedVariable, setEditedVariable] = useState<EditedVariable | null>(
     null,
   );
-  const [canApply, setCanApply] = useState<boolean>(false);
+  const [canCommit, setCanCommit] = useState<boolean>(false);
 
   useEffect(() => {
     setLocalUserVariables(userVariables);
@@ -135,8 +135,8 @@ export default function UserVariablesDialog({
             contextDataset={selectedDataset}
             expressionCapabilities={expressionCapabilities}
             serverUrl={serverUrl}
-            canApply={canApply}
-            setCanApply={setCanApply}
+            canCommit={canCommit}
+            setCanCommit={setCanCommit}
           />
         )}
       </DialogContent>
@@ -152,7 +152,7 @@ export default function UserVariablesDialog({
             <Button onClick={handleCancelFromEditor}>
               {i18n.get("Return")}
             </Button>
-            <Button onClick={handleApplyFromEditor} disabled={!canApply}>
+            <Button onClick={handleApplyFromEditor} disabled={!canCommit}>
               {i18n.get(editedVariable.editMode == "edit" ? "Apply" : "Add")}
             </Button>
           </Box>

--- a/src/components/UserVariablesDialog/UserVariablesDialog.tsx
+++ b/src/components/UserVariablesDialog/UserVariablesDialog.tsx
@@ -153,7 +153,7 @@ export default function UserVariablesDialog({
               {i18n.get("Return")}
             </Button>
             <Button onClick={handleApplyFromEditor} disabled={!canApply}>
-              {i18n.get("Apply")}
+              {i18n.get(editedVariable.editMode == "edit" ? "Apply" : "Add")}
             </Button>
           </Box>
         ) : (

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -1360,6 +1360,17 @@
       "de": "Permalink in die Zwischenablage kopiert (läuft ab in ${expiration} Tagen)",
       "se": "Permalink kopieras till klippbordet (går ut om ${expiration} dagar)"
     },
+
+    {
+      "en": "Return",
+      "de": "Zurück",
+      "se": "Tillbaka"
+    },
+    {
+      "en": "Apply",
+      "de": "Anwenden",
+      "se": "Anwända"
+    },
     {
       "en": "About ${appTitle}",
       "de": "Über ${appTitle}",

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -1372,6 +1372,11 @@
       "se": "Anwända"
     },
     {
+      "en": "Already in use",
+      "de": "Bereits in Verwendung",
+      "se": "Redan i bruk"
+    },
+    {
       "en": "About ${appTitle}",
       "de": "Über ${appTitle}",
       "se": "Om ${appTitle}"


### PR DESCRIPTION
This PR:
- restructures the process for adding and editing variables in the User Variables Dialog. The commit and cancel actions are no longer shown in the header, the bottom-right dialog buttons are now used for these actions.
- adds translations regarding the User Variables Dialog.
- updates the User Variables sections in the Viewer Docs.
- aims to solve the usability issues that became apparent in #529.

<img width="930" height="560" alt="image" src="https://github.com/user-attachments/assets/37842d6b-8f60-4b0b-acf2-fcec4d94c72c" />
