### PR TITLE
Clarasb 424 pinned variable dataset menu

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
    ![Logo](logo-dark.png#dark-mode-only)
    ```
 
+* A pin icon is now used in the dataset selector to mark a dataset
+  that holds a pinned variable. (#424)
+  
 ### Fixes
 
 *  Applied workaround for a bug in `html-to-image` libary that causes an 

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,8 +27,12 @@ A list of all the features that the viewer contains will be created here, in whi
 		<tr>
 			<td><b>Description</b></td>
 			<td>
-				A drop-down menu, which is grouped by data format. The selected dataset is
-				highlighted.
+				A drop-down menu, which holds all available datasets. The selected dataset is
+				highlighted and the dataset containing a 				
+        <a href="../user_guide/analyse/#pin-variables" rel="noopener noreferrer"
+					>pinned variable</a
+				> 
+        is marked with a <code>pin</code> icon.
 			</td>
 		</tr>
 		<tr></tr>
@@ -123,8 +127,11 @@ A list of all the features that the viewer contains will be created here, in whi
 				<a href="../user_guide/analyse/#user-variables" rel="noopener noreferrer"
 					>User-defined variables</a
 				>
-				are marked with an icon and placed at the bottom of the list. The
-				currently selected variable is highlighted.
+				are marked with an icon and placed at the bottom of the list and the 				
+        <a href="../user_guide/analyse/#pin-variables" rel="noopener noreferrer"
+					>pinned variable</a
+				> 
+        is marked with a <code>pin</code> icon. The currently selected variable is highlighted.
 			</td>
 		</tr>
 		<tr></tr>

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -8,7 +8,9 @@ import { ReactElement, useMemo } from "react";
 import Divider from "@mui/material/Divider";
 import Input from "@mui/material/Input";
 import InputLabel from "@mui/material/InputLabel";
+import ListItemText from "@mui/material/ListItemText";
 import MenuItem from "@mui/material/MenuItem";
+import PushPinIcon from "@mui/icons-material/PushPin";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -24,6 +26,7 @@ import ControlBarItem from "./ControlBarItem";
 
 interface DatasetSelectProps extends WithLocale {
   selectedDataset: Dataset | null;
+  selectedDataset2Id: string | null;
   datasets: Dataset[];
   selectDataset: (
     datasetId: string | null,
@@ -37,6 +40,7 @@ interface DatasetSelectProps extends WithLocale {
 
 export default function DatasetSelect({
   selectedDataset,
+  selectedDataset2Id,
   datasets,
   selectDataset,
   layerVisibilities,
@@ -125,7 +129,10 @@ export default function DatasetSelect({
         value={dataset.id}
         selected={dataset.id === selectedDatasetId}
       >
-        {dataset.title}
+        <ListItemText>{getDatasetLabel(dataset)} </ListItemText>
+        {dataset.id === selectedDataset2Id && (
+          <PushPinIcon fontSize="small" color="secondary" />
+        )}
       </MenuItem>,
     );
   });
@@ -138,6 +145,9 @@ export default function DatasetSelect({
       input={<Input name="dataset" id="dataset-select" />}
       displayEmpty
       name="dataset"
+      renderValue={() =>
+        getDatasetLabel(datasets.find((d) => d.id === selectedDatasetId))
+      }
     >
       {items}
     </Select>
@@ -180,4 +190,11 @@ export default function DatasetSelect({
       sx={{ marginLeft: 0 }}
     />
   );
+}
+
+function getDatasetLabel(dataset: Dataset | undefined) {
+  if (!dataset) {
+    return "?";
+  }
+  return dataset.title || dataset.id;
 }

--- a/src/connected/DatasetSelect.tsx
+++ b/src/connected/DatasetSelect.tsx
@@ -13,12 +13,16 @@ import {
   toggleDatasetRgbLayer,
   locateSelectedDatasetInMap,
 } from "@/actions/controlActions";
-import { selectedDatasetSelector } from "@/selectors/controlSelectors";
+import {
+  selectedDatasetSelector,
+  selectedDataset2IdSelector,
+} from "@/selectors/controlSelectors";
 
 const mapStateToProps = (state: AppState) => {
   return {
     locale: state.controlState.locale,
     selectedDataset: selectedDatasetSelector(state),
+    selectedDataset2Id: selectedDataset2IdSelector(state),
     datasets: state.dataState.datasets,
     layerVisibilities: state.controlState.layerVisibilities,
   };


### PR DESCRIPTION
This PR:
- adds a pin icon to the dataset in the dataset selector that contains a pinned variable
- docs: updates information on `Select Dataset` and `Select Variable` in the Feature References
- closes #424 

<img width="365" height="221" alt="image" src="https://github.com/user-attachments/assets/f1b34f73-e9a5-4c5d-9352-ab6ce8c9135e" />
