### PR TITLE
Allow map to report tile load progress

### DIFF
--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -4,7 +4,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Theme, useTheme } from "@mui/system";
 import * as geojson from "geojson";
 import { default as OlMap } from "ol/Map";
@@ -46,7 +46,7 @@ import { ScaleLine } from "@/components/ol/control/ScaleLine";
 import { Draw, DrawEvent } from "@/components/ol/interaction/Draw";
 import { Layers } from "@/components/ol/layer/Layers";
 import { Vector } from "@/components/ol/layer/Vector";
-import { Map, MapElement } from "@/components/ol/Map";
+import { Map, MapElement, TileLoadProgress } from "@/components/ol/Map";
 import { View } from "@/components/ol/View";
 import { setFeatureStyle } from "@/components/ol/style";
 import { findMapLayer } from "@/components/ol/util";
@@ -351,6 +351,10 @@ export default function Viewer({
     }
   };
 
+  const handleTileLoadProgress = useCallback((p: TileLoadProgress) => {
+    console.log("tile load progress:", p);
+  }, []);
+
   return (
     <ErrorBoundary>
       <Map
@@ -360,6 +364,7 @@ export default function Viewer({
         mapObjects={MAP_OBJECTS}
         isStale={true}
         onDropFiles={handleDropFiles}
+        onTileLoadProgress={handleTileLoadProgress}
       >
         <View id="view" projection={mapProjection} />
         <Layers>

--- a/src/components/ol/Map.tsx
+++ b/src/components/ol/Map.tsx
@@ -39,6 +39,7 @@ export interface MapContext {
 
 export const MapContextType = React.createContext<MapContext>({
   mapObjects: {},
+  // values are initially dummy handlers
   reportTileLoadStart: () => {},
   reportTileLoadEnd: () => {},
   reportTileLoadError: () => {},
@@ -213,6 +214,7 @@ export class Map extends React.Component<MapProps, MapState> {
     delete mapOptions["children"];
     delete mapOptions["onClick"];
     delete mapOptions["onDropFiles"];
+    delete mapOptions["onTileLoadProgress"];
     return mapOptions;
   }
 
@@ -323,27 +325,29 @@ export class Map extends React.Component<MapProps, MapState> {
   ) => {
     const onTileLoadProgress = this.props.onTileLoadProgress;
     if (onTileLoadProgress) {
+      // Only report if we have a handler
       this.setState(updater, this.reportProgressUpdate);
     }
   };
 
   private reportProgressUpdate = () => {
     const onTileLoadProgress = this.props.onTileLoadProgress;
-    if (onTileLoadProgress) {
-      const prevProgress = this.lastTileLoadProgress;
-      // Note, we could also report tile load errors here
-      const newProgress = {
-        value: this.computeProgressValue(),
-        active: this.isProgressActive(),
-      };
-      if (
-        !prevProgress ||
-        prevProgress.active !== newProgress.active ||
-        prevProgress.value !== newProgress.value
-      ) {
-        this.lastTileLoadProgress = newProgress;
-        onTileLoadProgress(newProgress);
-      }
+    if (!onTileLoadProgress) {
+      return;
+    }
+    const prevProgress = this.lastTileLoadProgress;
+    // Note, we could also report tile load errors here
+    const newProgress = {
+      value: this.computeProgressValue(),
+      active: this.isProgressActive(),
+    };
+    if (
+      !prevProgress ||
+      prevProgress.active !== newProgress.active ||
+      prevProgress.value !== newProgress.value
+    ) {
+      onTileLoadProgress(newProgress);
+      this.lastTileLoadProgress = newProgress;
     }
   };
 

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -13,6 +13,8 @@ import { default as OlUrlTileSource } from "ol/source/UrlTile";
 import { default as OlXYZSource } from "ol/source/XYZ";
 import { default as OlOSMSource } from "ol/source/OSM";
 import { Options as OlTileLayerOptions } from "ol/layer/BaseTile";
+import { EventsKey as OlEventsKey } from "ol/events";
+import { unByKey as ol_unByKey } from "ol/Observable";
 
 import { MapComponent, MapComponentProps } from "../MapComponent";
 import { processLayerProperties } from "./common";
@@ -51,22 +53,24 @@ interface TileProps
     OlTileLayerOptions<OlTileSource> {}
 
 export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
+  tileLoadStartEventsKey: OlEventsKey | null = null;
+  tileLoadEndEventsKey: OlEventsKey | null = null;
+  tileLoadErrorEventsKey: OlEventsKey | null = null;
+
   addMapObject(map: OlMap): OlTileLayer<OlTileSource> {
     const layer = new OlTileLayer(this.props);
     layer.set("id", this.props.id);
 
-    //The below lines of code of setting source as "Anonymous" is for allowing
-    //to copy image on clipboard as we have custom tiles. If the source is
-    //not set to anonymous it will give the CORS error and image will not be copied.
-    //Source link: https://openlayers.org/en/latest/examples/wms-custom-proj.html
+    // The below lines of code of setting source as "Anonymous" is for allowing
+    // to copy image on clipboard as we have custom tiles. If the source is
+    // not set to anonymous it will give the CORS error and image will not be copied.
+    // Source link: https://openlayers.org/en/latest/examples/wms-custom-proj.html
     const source = layer.getSource() as OlTileSource & { crossOrigin?: string };
     if (source) {
       if ("crossOrigin" in source) {
         source.crossOrigin = "Anonymous";
       }
-      // TODO: forman: cont. work here
-      source.on("tileloadstart", () => {});
-      source.on("tileloadend", () => {});
+      this.registerTileLoadHandlers(source);
     }
     map.getLayers().push(layer);
     return layer;
@@ -144,6 +148,11 @@ export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
       }
 
       if (replaceSource) {
+        // re-register tileLoadStart and tileLoadEnd handlers
+        if (oldSource) {
+          this.unregisterTileLoadHandlers(oldSource);
+        }
+        this.registerTileLoadHandlers(newSource);
         // Replace the entire source and accept layer flickering.
         layer.setSource(newSource);
         trace("--> Replaced source (expect flickering!)");
@@ -156,7 +165,32 @@ export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
   }
 
   removeMapObject(map: OlMap, layer: OlTileLayer<OlTileSource>): void {
+    const source = layer.getSource() as OlTileSource;
+    if (source) {
+      this.unregisterTileLoadHandlers(source);
+    }
     map.getLayers().remove(layer);
+  }
+
+  private registerTileLoadHandlers(source: OlTileSource): void {
+    this.tileLoadStartEventsKey = source.on(
+      "tileloadstart",
+      this.context.reportTileLoadStart,
+    );
+    this.tileLoadEndEventsKey = source.on(
+      "tileloadend",
+      this.context.reportTileLoadEnd,
+    );
+    this.tileLoadErrorEventsKey = source.on(
+      "tileloaderror",
+      this.context.reportTileLoadError,
+    );
+  }
+
+  unregisterTileLoadHandlers(_source: OlTileSource): void {
+    ol_unByKey(this.tileLoadStartEventsKey!);
+    ol_unByKey(this.tileLoadEndEventsKey!);
+    ol_unByKey(this.tileLoadErrorEventsKey!);
   }
 }
 

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -23,7 +23,7 @@ let trace: (message?: string, ...optionalParams: unknown[]) => void;
 if (import.meta.env.DEV && DEBUG) {
   trace = console.debug;
 } else {
-  trace = () => { };
+  trace = () => {};
 }
 
 // noinspection JSUnusedGlobalSymbols
@@ -48,20 +48,25 @@ export function OSMBlackAndWhite(): JSX.Element {
 
 interface TileProps
   extends MapComponentProps,
-  OlTileLayerOptions<OlTileSource> { }
+    OlTileLayerOptions<OlTileSource> {}
 
 export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
   addMapObject(map: OlMap): OlTileLayer<OlTileSource> {
     const layer = new OlTileLayer(this.props);
     layer.set("id", this.props.id);
 
-    //The below lines of code of setting source as "Anonymous" is for allowing 
-    //to copy image on clipboard as we have custom tiles. If the source is 
+    //The below lines of code of setting source as "Anonymous" is for allowing
+    //to copy image on clipboard as we have custom tiles. If the source is
     //not set to anonymous it will give the CORS error and image will not be copied.
-    //Source link: https://openlayers.org/en/latest/examples/wms-custom-proj.html 
+    //Source link: https://openlayers.org/en/latest/examples/wms-custom-proj.html
     const source = layer.getSource() as OlTileSource & { crossOrigin?: string };
-    if (source && 'crossOrigin' in source) {
-      source.crossOrigin = "Anonymous";
+    if (source) {
+      if ("crossOrigin" in source) {
+        source.crossOrigin = "Anonymous";
+      }
+      // TODO: forman: cont. work here
+      source.on("tileloadstart", () => {});
+      source.on("tileloadend", () => {});
     }
     map.getLayers().push(layer);
     return layer;

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -173,6 +173,7 @@ export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
   }
 
   private registerTileLoadHandlers(source: OlTileSource): void {
+    console.log("adding tile load handlers to", source);
     this.tileLoadStartEventsKey = source.on(
       "tileloadstart",
       this.context.reportTileLoadStart,
@@ -187,7 +188,8 @@ export class Tile extends MapComponent<OlTileLayer<OlTileSource>, TileProps> {
     );
   }
 
-  unregisterTileLoadHandlers(_source: OlTileSource): void {
+  private unregisterTileLoadHandlers(source: OlTileSource): void {
+    console.log("removing tile load handlers from", source);
     ol_unByKey(this.tileLoadStartEventsKey!);
     ol_unByKey(this.tileLoadEndEventsKey!);
     ol_unByKey(this.tileLoadErrorEventsKey!);


### PR DESCRIPTION
The `Map` component can now report progress through the `onTileLoadProgress: (p: TileLoadProgress)` property (addressing #283). Current usage demo implements this handler to output progress to the console:

<img width="1522" height="937" alt="image" src="https://github.com/user-attachments/assets/7cba78a6-48a2-4164-92ae-db217092652e" />

This should be changed to change the app state, so a progress component can reflect this.