### PR TITLE
Update ESLint and Prettier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
   - `storybook 9.1.12` (updated from v7)
   - `vitest 3.2.4`
   - `eslint 9.38.0`
+  - `prettier 3.6.2`
   
   - `@chromatic-com/storybook 4.1.1`
   - `@eslint/compat 1.4.0` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "globals": "^16.0.0",
         "jsdom": "^24.0.0",
         "microdiff": "^1.4.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.6.2",
         "storybook": "^9.1.12",
         "typescript": "5.1.6",
         "vite": "^7.1.11",
@@ -7798,7 +7798,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "globals": "^16.0.0",
     "jsdom": "^24.0.0",
     "microdiff": "^1.4.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.6.2",
     "storybook": "^9.1.12",
     "typescript": "5.1.6",
     "vite": "^7.1.11",


### PR DESCRIPTION
This PR updates 
- the `eslint` dependency to ^9.38.0 and the related dependencies
- the `prettier` dependency to ^3.6.2 