### PR TITLE
Restructure `Workspace.tsx`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,14 @@
 * Show dataset level in the zoom level info box also if no dataset variable is being 
   displayed (when in RGB-only mode). (#576)
   
-* Fix zoom level info box not updating correctly when opening a viewer 
+* Fixed zoom level info box not updating correctly when opening a viewer 
   from a permalink. (#581)
 
-* Ensure that a persited viewer state gets restored after accepting the
+* Ensured that a persited viewer state gets restored after accepting the
   LegalAgreementDialog. (#570)
 
+* Fixed a problem that caused the ProgressBar to appear stuck when 
+  changing the state of the sidebar. (#592)
 
 ## Changes in version 1.7.1
 

--- a/src/components/SidePanel/styles.ts
+++ b/src/components/SidePanel/styles.ts
@@ -8,6 +8,8 @@ import type { Theme } from "@mui/system";
 
 import { makeStyles } from "@/util/styles";
 
+export const SIDEBAR_WIDTH: number = 46.5;
+
 const sidePanelThemeDark = {
   sidebarColor: "#181818",
   backgroundColor: "#1F1F1F",
@@ -66,6 +68,7 @@ const styles = makeStyles({
     borderTop: `1px solid ${getBorderColor(theme)}`,
     backgroundColor: getSidebarColor(theme),
     flex: "0 0 auto",
+    width: SIDEBAR_WIDTH,
   }),
   sidebarButton: (theme) => ({
     color: theme.palette.text.secondary,

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -97,6 +97,7 @@ export interface SplitPaneProps {
   updateChildSize: (childSize: number) => void;
   style?: CSSProperties;
   children: React.ReactNode[];
+  showResizeHandle?: boolean;
 }
 
 /**
@@ -110,6 +111,7 @@ export default function SplitPane({
   updateChildSize,
   children,
   style,
+  showResizeHandle = true,
 }: PropsWithChildren<SplitPaneProps>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const child1Ref = useRef<HTMLDivElement>(null);
@@ -165,11 +167,13 @@ export default function SplitPane({
         {children[0]}
       </Box>
       <Box id="SplitPane-Child2" sx={computedStyles.child2}>
-        <Box
-          id="SplitPane-ResizeHandle"
-          sx={computedStyles.resizeHandle}
-          onMouseDown={handleMouseDown}
-        />
+        {showResizeHandle && (
+          <Box
+            id="SplitPane-ResizeHandle"
+            sx={computedStyles.resizeHandle}
+            onMouseDown={handleMouseDown}
+          />
+        )}
         {children[1]}
       </Box>
     </Box>

--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -97,7 +97,8 @@ export interface SplitPaneProps {
   updateChildSize: (childSize: number) => void;
   style?: CSSProperties;
   children: React.ReactNode[];
-  showResizeHandle?: boolean;
+  // disable resizing, if panel content is not visible
+  resizeable?: boolean;
 }
 
 /**
@@ -111,7 +112,7 @@ export default function SplitPane({
   updateChildSize,
   children,
   style,
-  showResizeHandle = true,
+  resizeable = true,
 }: PropsWithChildren<SplitPaneProps>) {
   const containerRef = useRef<HTMLDivElement>(null);
   const child1Ref = useRef<HTMLDivElement>(null);
@@ -167,7 +168,7 @@ export default function SplitPane({
         {children[0]}
       </Box>
       <Box id="SplitPane-Child2" sx={computedStyles.child2}>
-        {showResizeHandle && (
+        {resizeable && (
           <Box
             id="SplitPane-ResizeHandle"
             sx={computedStyles.resizeHandle}

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -126,7 +126,7 @@ function WorkspaceImpl({
       childPos={"last"}
       childSize={effectiveChildSize}
       updateChildSize={showPanelContent ? updateSidePanelSize : () => {}}
-      showResizeHandle={showPanelContent}
+      resizeable={showPanelContent}
       style={layout === "hor" ? styles.containerHor : styles.containerVer}
     >
       <div style={styles.viewer}>

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -37,8 +37,6 @@ const styles = makeCssStyles({
     overflow: "hidden",
     width: "100%",
     height: "100%",
-    /*    minWidth: 0,
-    minHeight: 0,*/
   },
 
   sidePanelSplit: {
@@ -115,10 +113,8 @@ function WorkspaceImpl({
     setLayout(getLayout());
   };
 
-  const showSidebar = sidePanelOpen;
   const showPanelContent = sidePanelOpen && !!sidePanelId;
-
-  const effectiveChildSize = !showSidebar
+  const effectiveChildSize = !sidePanelOpen
     ? 0
     : showPanelContent
       ? sidePanelSize
@@ -139,7 +135,7 @@ function WorkspaceImpl({
 
       <Box
         sx={
-          showSidebar
+          sidePanelOpen
             ? showPanelContent
               ? styles.sidePanelSplit
               : layout === "hor"

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -13,6 +13,7 @@ import Box from "@mui/material/Box";
 import { AppState } from "@/states/appState";
 import { updateSidePanelSize } from "@/actions/controlActions";
 import SplitPane from "@/components/SplitPane";
+import { SIDEBAR_WIDTH } from "@/components/SidePanel/styles";
 import Viewer from "./Viewer";
 import SidePanel from "./SidePanel";
 import { makeCssStyles } from "@/util/styles";
@@ -23,31 +24,40 @@ const styles = makeCssStyles({
   containerHor: {
     flexGrow: 1,
     overflow: "hidden",
+    height: "100%",
   },
   containerVer: {
     flexGrow: 1,
     overflowX: "hidden",
     overflowY: "auto",
-  },
-
-  noSplitHor: {
-    display: "flex",
-    flexDirection: "row",
     height: "100%",
-  },
-  noSplitVer: {
-    display: "flex",
-    flexDirection: "column",
   },
 
   viewer: {
     overflow: "hidden",
     width: "100%",
     height: "100%",
+    /*    minWidth: 0,
+    minHeight: 0,*/
   },
 
-  sidebarAlone: {
+  sidePanelSplit: {
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+  },
+
+  sidePanelNoPanelHor: {
     flexGrow: 0,
+    height: "100%",
+  },
+
+  sidePanelNoPanelVer: {
+    flexGrow: 0,
+  },
+
+  sidePanelHidden: {
+    display: "none",
   },
 });
 
@@ -99,46 +109,49 @@ function WorkspaceImpl({
     if (map) {
       map.updateSize();
     }
-  }, [map, sidePanelSize]);
+  }, [map, sidePanelSize, sidePanelOpen, sidePanelId, layout]);
 
   const updateLayout = () => {
     setLayout(getLayout());
   };
 
-  if (sidePanelOpen) {
-    if (sidePanelId) {
-      // Viewer & Panel & Sidebar
-      return (
-        <SplitPane
-          dir={layout}
-          childPos={"last"}
-          childSize={sidePanelSize}
-          updateChildSize={updateSidePanelSize}
-          style={layout === "hor" ? styles.containerHor : styles.containerVer}
-        >
-          <Viewer onMapRef={setMap} theme={theme} />
-          <SidePanel />
-        </SplitPane>
-      );
-    } else {
-      // Viewer & Sidebar - no Panel
-      return (
-        <Box sx={layout === "hor" ? styles.noSplitHor : styles.noSplitVer}>
-          <Viewer onMapRef={setMap} theme={theme} />
-          <div style={styles.sidebarAlone}>
-            <SidePanel />
-          </div>
-        </Box>
-      );
-    }
-  } else {
-    // Viewer alone - no Panel, no Sidebar
-    return (
+  const showSidebar = sidePanelOpen;
+  const showPanelContent = sidePanelOpen && !!sidePanelId;
+
+  const effectiveChildSize = !showSidebar
+    ? 0
+    : showPanelContent
+      ? sidePanelSize
+      : SIDEBAR_WIDTH;
+
+  return (
+    <SplitPane
+      dir={layout}
+      childPos={"last"}
+      childSize={effectiveChildSize}
+      updateChildSize={showPanelContent ? updateSidePanelSize : () => {}}
+      showResizeHandle={showPanelContent}
+      style={layout === "hor" ? styles.containerHor : styles.containerVer}
+    >
       <div style={styles.viewer}>
         <Viewer onMapRef={setMap} theme={theme} />
       </div>
-    );
-  }
+
+      <Box
+        sx={
+          showSidebar
+            ? showPanelContent
+              ? styles.sidePanelSplit
+              : layout === "hor"
+                ? styles.sidePanelNoPanelHor
+                : styles.sidePanelNoPanelVer
+            : styles.sidePanelHidden
+        }
+      >
+        <SidePanel />
+      </Box>
+    </SplitPane>
+  );
 }
 
 const Workspace = connect(mapStateToProps, mapDispatchToProps)(WorkspaceImpl);


### PR DESCRIPTION
This PR restructures `Workspace` to always return **a single component tree**, ensuring that the `Viewer` component remains mounted. Only the surrounding layout (`Sidebar` / `Panel` / `SplitPane`) changes based on the current UI state.

This fixes the ProgressBar getting stuck upon layout changes.