### PR TITLE
Fix tile cut-off for unsupported CRS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Changes in version 1.7.3 (in development)
 
+### Fixes
+
+* Fixed tile visualization for projected datasets (e.g. UTM, LAEA).
+  Layer extents are now only applied for supported CRS (EPSG:4326, EPSG:3857) 
+  to avoid incorrect cut-offs. (#595)
+
 ## Changes in version 1.7.2
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-* Fixed tile visualization for projected datasets (e.g. UTM, LAEA).
+* Fixed tile visualization for datasets with unsupported CRS (e.g. UTM, LAEA).
   Layer extents are now only applied for supported CRS (EPSG:4326, EPSG:3857) 
   to avoid incorrect cut-offs. (#593)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Fixed tile visualization for projected datasets (e.g. UTM, LAEA).
   Layer extents are now only applied for supported CRS (EPSG:4326, EPSG:3857) 
-  to avoid incorrect cut-offs. (#595)
+  to avoid incorrect cut-offs. (#593)
 
 ## Changes in version 1.7.2
 

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -948,7 +948,10 @@ function getTileLayer(
 
   let transformedExtent;
 
-  if (datasetProjection === GEOGRAPHIC_CRS || WEB_MERCATOR_CRS) {
+  if (
+    datasetProjection === GEOGRAPHIC_CRS ||
+    datasetProjection === WEB_MERCATOR_CRS
+  ) {
     if (mapProjection === datasetProjection) {
       transformedExtent = extent;
     } else {

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -952,6 +952,12 @@ function getTileLayer(
     datasetProjection === GEOGRAPHIC_CRS ||
     datasetProjection === WEB_MERCATOR_CRS
   ) {
+    // Only use extent for EPSG:4326 and EPSG:3857.
+    // For other CRS (e.g. UTM, LAEA), transforming the bbox can be inaccurate
+    // and may clip valid tiles due to projection distortion.
+    // Disabling extent avoids rendering artifacts. It can trigger extra
+    // tile requests, but the performance impact should be small
+    // as xcube Server already handles out-of-bounds tiles.
     if (mapProjection === datasetProjection) {
       transformedExtent = extent;
     } else {
@@ -962,7 +968,6 @@ function getTileLayer(
       );
     }
   } else {
-    // For unsupported CRS (e.g. UTM, LAEA)
     transformedExtent = undefined;
   }
 

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -919,6 +919,7 @@ function getTileLayer(
   timeLabel: string | null,
   timeAnimationActive: boolean,
   mapProjection: string,
+  datasetProjection: string,
   attributions: string[] | null,
   imageSmoothing: boolean,
   zIndex: number = 10,
@@ -944,10 +945,24 @@ function getTileLayer(
     tileLevelMin,
     tileLevelMax,
   );
-  const transformedExtent =
-    mapProjection === GEOGRAPHIC_CRS
-      ? extent
-      : olTransformExtent(extent, "EPSG:4326", mapProjection);
+
+  let transformedExtent;
+
+  if (datasetProjection === GEOGRAPHIC_CRS || WEB_MERCATOR_CRS) {
+    if (mapProjection === datasetProjection) {
+      transformedExtent = extent;
+    } else {
+      transformedExtent = olTransformExtent(
+        extent,
+        datasetProjection,
+        mapProjection,
+      );
+    }
+  } else {
+    // For unsupported CRS (e.g. UTM, LAEA)
+    transformedExtent = undefined;
+  }
+
   return (
     <Tile
       id={layerId}
@@ -1078,6 +1093,7 @@ const getVariableTileLayer = (
     timeLabel,
     timeAnimationActive,
     mapProjection,
+    dataset.spatialRef,
     attributions,
     imageSmoothing,
     zIndex,
@@ -1152,6 +1168,7 @@ const getDatasetRgbTileLayer = (
     timeLabel,
     timeAnimationActive,
     mapProjection,
+    dataset.spatialRef,
     attributions,
     imageSmoothing,
     zIndex,


### PR DESCRIPTION
This PR fixes an issue where datasets in projected coordinate systems (e.g. UTM `EPSG:32633`, LAEA `EPSG:3035`) were only partially visible in the Viewer. For example see #593 

Tiles were correctly generated and returned by the xcube Server, but parts of them were not rendered due to incorrect extent handling in xcube Viewer.

**Cause**
- xcube Viewer assumed that all dataset extents are defined in `EPSG:4326`. This caused incorrect extent transformations for datasets in other CRS, leading to clipping of valid tiles (typically on the west and north edges).

**Solution**
- Use `dataset.spatialRef` instead of assuming `EPSG:4326`, apply extent transformation only for supported CRS (`EPSG:4326`, `EPSG:3857`), and disable extent-based clipping for all other CRS to avoid rendering artifacts.


Closes #593.