### PR TITLE
add seach and collapse function to dataset selection

### DIFF
--- a/src/components/DatasetSelect.stories.tsx
+++ b/src/components/DatasetSelect.stories.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { Dataset } from "@/model/dataset";
+import DatasetSelect from "./DatasetSelect";
+
+interface DatasetSelectDemoProps {
+  datasets: Dataset[];
+  selectedDatasetId: string | null;
+  selectedDataset2Id: string | null;
+}
+
+const datasets: Dataset[] = [
+  createDataset("de-berlin", "Berlin Sentinel-2", "Germany", 1, 1),
+  createDataset("de-hamburg", "Hamburg Urban Heat", "Germany", 1, 2),
+  createDataset("de-munich", "Munich Vegetation", "Germany", 1, 3),
+  createDataset("fr-paris", "Paris Land Cover", "France", 2, 1),
+  createDataset("fr-lyon", "Lyon Air Quality", "France", 2, 2),
+  createDataset("fr-marseille", "Marseille Coastal", "France", 2, 3),
+  createDataset("es-madrid", "Madrid Drought Index", "Spain", 3, 1),
+  createDataset("es-barcelona", "Barcelona Canopy", "Spain", 3, 2),
+  createDataset("es-valencia", "Valencia Agriculture", "Spain", 3, 3),
+  createDataset("it-rome", "Rome Surface Water", "Italy", 4, 1),
+  createDataset("it-milan", "Milan Imperviousness", "Italy", 4, 2),
+  createDataset("unclassified", "Unclassified Test Dataset", undefined, 5, 1),
+];
+
+function DatasetSelectDemo({
+  datasets,
+  selectedDatasetId,
+  selectedDataset2Id,
+}: DatasetSelectDemoProps) {
+  const selectedDataset =
+    datasets.find((dataset) => dataset.id === selectedDatasetId) ?? null;
+
+  return (
+    <DatasetSelect
+      selectedDataset={selectedDataset}
+      selectedDataset2Id={selectedDataset2Id}
+      datasets={datasets}
+      selectDataset={() => {}}
+      layerVisibilities={{
+        datasetRgb: false,
+        datasetVariable: true,
+      }}
+      toggleDatasetRgbLayer={() => {}}
+      locateSelectedDataset={() => {}}
+    />
+  );
+}
+
+const meta = {
+  component: DatasetSelectDemo,
+  title: "DatasetSelect",
+  parameters: {
+    // Optional parameter to center the component in the Canvas.
+    // More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry:
+  // https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+} satisfies Meta<typeof DatasetSelectDemo>;
+
+// noinspection JSUnusedGlobalSymbols
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Grouped: Story = {
+  args: {
+    datasets,
+    selectedDatasetId: "de-hamburg",
+    selectedDataset2Id: "fr-paris",
+  },
+};
+
+function createDataset(
+  id: string,
+  title: string,
+  groupTitle: string | undefined,
+  groupOrder: number,
+  sortValue: number,
+): Dataset {
+  return {
+    id,
+    title,
+    groupTitle,
+    groupOrder,
+    groupDescription: groupTitle
+      ? `Datasets grouped under ${groupTitle}.`
+      : undefined,
+    sortValue,
+    bbox: [0, 0, 1, 1],
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ],
+    },
+    spatialRef: "EPSG:4326",
+    dimensions: [],
+    variables: [],
+    attrs: {},
+    resolutions: [1],
+    spatialUnits: "degrees",
+  };
+}

--- a/src/components/DatasetSelect.stories.tsx
+++ b/src/components/DatasetSelect.stories.tsx
@@ -58,25 +58,88 @@ const meta = {
   component: DatasetSelectDemo,
   title: "DatasetSelect",
   parameters: {
-    // Optional parameter to center the component in the Canvas.
-    // More info: https://storybook.js.org/docs/configure/story-layout
     layout: "centered",
   },
-  // This component will have an automatically generated Autodocs entry:
-  // https://storybook.js.org/docs/writing-docs/autodocs
   tags: ["autodocs"],
 } satisfies Meta<typeof DatasetSelectDemo>;
 
-// noinspection JSUnusedGlobalSymbols
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Grouped: Story = {
+export const GroupedOneSelected: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Datasets are organized into multiple groups. Demonstrates group headers, collapsing/expanding, tooltips, and one selected dataset.",
+      },
+    },
+  },
+  args: {
+    datasets,
+    selectedDatasetId: "de-hamburg",
+    selectedDataset2Id: null,
+  },
+};
+
+export const GroupedTwoSelected: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "This story demonstrates a component with two selected datasets.",
+      },
+    },
+  },
   args: {
     datasets,
     selectedDatasetId: "de-hamburg",
     selectedDataset2Id: "fr-paris",
+  },
+};
+
+export const SingleGroup: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "All datasets belong to the same group. Demonstrates that group headers are not rendered when all datasets share the same group.",
+      },
+    },
+  },
+  args: {
+    datasets: datasets.filter((dataset) => dataset.groupTitle === "Germany"),
+    selectedDatasetId: "de-hamburg",
+    selectedDataset2Id: null,
+  },
+};
+
+export const NoGroups: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Datasets do not belong to any group. Demonstrates the component's behavior when groupTitle is undefined.",
+      },
+    },
+  },
+  args: {
+    datasets: datasets.map((dataset) => ({
+      ...dataset,
+      groupTitle: undefined,
+      groupDescription: undefined,
+    })),
+    selectedDatasetId: "de-hamburg",
+    selectedDataset2Id: null,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    datasets: [],
+    selectedDatasetId: null,
+    selectedDataset2Id: null,
   },
 };
 

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -17,6 +17,7 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import TravelExploreIcon from "@mui/icons-material/TravelExplore";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
 import i18n from "@/i18n";
 import type { Dataset } from "@/model/dataset";
@@ -90,8 +91,19 @@ export default function DatasetSelect({
   const hasMultipleGroups =
     new Set(sortedDatasets.map(getDatasetGroupLabel)).size > 1;
 
+  // this where to set the threshold to decide whether to collapse groups by default or not
+  const collapseGroupsByDefault = sortedDatasets.length > 10;
+
   const selectedDatasetGroupTitle = selectedDataset
     ? getDatasetGroupLabel(selectedDataset)
+    : undefined;
+
+  const selectedDataset2 = sortedDatasets.find(
+    (d) => d.id === selectedDataset2Id,
+  );
+
+  const selectedDataset2GroupTitle = selectedDataset2
+    ? getDatasetGroupLabel(selectedDataset2)
     : undefined;
 
   // Group handling functions for rendering group headers, descriptions, and collapse/expand state
@@ -100,19 +112,31 @@ export default function DatasetSelect({
       (dataset) => getDatasetGroupLabel(dataset) === groupTitle,
     )?.groupDescription;
 
+  const isDefaultExpanded = (groupTitle: string) => {
+    if (!collapseGroupsByDefault) {
+      return true;
+    }
+
+    return (
+      groupTitle === selectedDatasetGroupTitle ||
+      groupTitle === selectedDataset2GroupTitle
+    );
+  };
+
   const isGroupExpanded = (groupTitle: string) =>
     isFilteringDatasets ||
-    (expandedGroups[groupTitle] ?? groupTitle === selectedDatasetGroupTitle);
+    (expandedGroups[groupTitle] ?? isDefaultExpanded(groupTitle));
 
   const toggleGroupExpanded = (groupTitle: string) => {
-    setExpandedGroups((currentExpandedGroups) => ({
-      ...currentExpandedGroups,
-      [groupTitle]: !(
-        isFilteringDatasets ||
-        (currentExpandedGroups[groupTitle] ??
-          groupTitle === selectedDatasetGroupTitle)
-      ),
-    }));
+    setExpandedGroups((currentExpandedGroups) => {
+      const currentlyExpanded =
+        currentExpandedGroups[groupTitle] ?? isDefaultExpanded(groupTitle);
+
+      return {
+        ...currentExpandedGroups,
+        [groupTitle]: !currentlyExpanded,
+      };
+    });
   };
 
   const selectedDatasetId = selectedDataset?.id ?? "";
@@ -140,7 +164,6 @@ export default function DatasetSelect({
       getOptionLabel={getDatasetLabel}
       groupBy={hasMultipleGroups ? getDatasetGroupLabel : undefined}
       isOptionEqualToValue={(option, value) => option.id === value.id}
-      disableClearable={!!selectedDataset}
       autoHighlight
       blurOnSelect
       sx={{
@@ -168,36 +191,41 @@ export default function DatasetSelect({
               px: 0.75,
               py: 0,
               color: "text.secondary",
-              "&::before, &::after": {
-                content: '""',
-                borderTop: 1,
-                borderColor: "divider",
-                flex: 1,
-              },
-              "&::before": { mr: 1 },
-              "&::after": { ml: 1 },
             }}
           >
             <Typography fontSize="small" color="text.secondary">
               {params.group}
             </Typography>
+
+            <Typography
+              component="span"
+              sx={{
+                flex: 1,
+                borderTop: 1,
+                borderColor: "divider",
+                mx: 1,
+              }}
+            />
+            {groupDescription && (
+              <Tooltip arrow title={groupDescription}>
+                <InfoOutlinedIcon
+                  fontSize="small"
+                  sx={{ mr: 0.5 }}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </Tooltip>
+            )}
             {expanded ? (
-              <ExpandLessIcon fontSize="small" sx={{ ml: 0.25 }} />
+              <ExpandLessIcon fontSize="small" />
             ) : (
-              <ExpandMoreIcon fontSize="small" sx={{ ml: 0.25 }} />
+              <ExpandMoreIcon fontSize="small" />
             )}
           </ListItemButton>
         );
 
         return (
           <li key={params.key}>
-            {groupDescription ? (
-              <Tooltip arrow title={groupDescription}>
-                {groupTitle}
-              </Tooltip>
-            ) : (
-              groupTitle
-            )}
+            {groupTitle}
             <Collapse in={expanded} timeout="auto" unmountOnExit>
               <ul style={{ margin: 0, padding: 0 }}>{params.children}</ul>
             </Collapse>

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -55,53 +55,52 @@ export default function DatasetSelect({
   const [isFilteringDatasets, setIsFilteringDatasets] = useState(false);
 
   const sortedDatasets = useMemo(() => {
-    return [...(datasets || [])].sort(
-      (dataset1: Dataset, dataset2: Dataset) => {
-        const groupOrder1 = dataset1.groupOrder ?? Infinity;
-        const groupOrder2 = dataset2.groupOrder ?? Infinity;
+    return [...datasets].sort((dataset1: Dataset, dataset2: Dataset) => {
+      const groupOrder1 = dataset1.groupOrder ?? Infinity;
+      const groupOrder2 = dataset2.groupOrder ?? Infinity;
 
-        if (groupOrder1 !== groupOrder2) {
-          return groupOrder1 - groupOrder2;
-        }
+      if (groupOrder1 !== groupOrder2) {
+        return groupOrder1 - groupOrder2;
+      }
 
-        const groupTitle1 = dataset1.groupTitle || "zzz";
-        const groupTitle2 = dataset2.groupTitle || "zzz";
-        const delta = groupTitle1.localeCompare(groupTitle2);
-        if (delta !== 0) {
-          return delta;
-        }
-        const sortValue1 = dataset1.sortValue;
-        const sortValue2 = dataset2.sortValue;
+      const groupTitle1 = dataset1.groupTitle || "zzz";
+      const groupTitle2 = dataset2.groupTitle || "zzz";
+      const delta = groupTitle1.localeCompare(groupTitle2);
+      if (delta !== 0) {
+        return delta;
+      }
+      const sortValue1 = dataset1.sortValue;
+      const sortValue2 = dataset2.sortValue;
 
-        // Handles when both sortValue are available
-        if (sortValue1 !== undefined && sortValue2 !== undefined) {
-          return sortValue1 - sortValue2;
-        }
+      // Handles when both sortValue are available
+      if (sortValue1 !== undefined && sortValue2 !== undefined) {
+        return sortValue1 - sortValue2;
+      }
 
-        // Handles when no sortValue is available
-        if (sortValue1 === undefined && sortValue2 === undefined) {
-          return dataset1.title.localeCompare(dataset2.title);
-        }
+      // Handles when no sortValue is available
+      if (sortValue1 === undefined && sortValue2 === undefined) {
+        return dataset1.title.localeCompare(dataset2.title);
+      }
 
-        // Handles when only one sortValue is available
-        return sortValue1 !== undefined ? -1 : 1;
-      },
-    );
+      // Handles when only one sortValue is available
+      return sortValue1 !== undefined ? -1 : 1;
+    });
   }, [datasets]);
 
   const hasMultipleGroups =
-    new Set(sortedDatasets.map(getDatasetGroupTitle)).size > 1;
+    new Set(sortedDatasets.map(getDatasetGroupLabel)).size > 1;
 
   const selectedDatasetGroupTitle = selectedDataset
-    ? getDatasetGroupTitle(selectedDataset)
+    ? getDatasetGroupLabel(selectedDataset)
     : undefined;
 
+  // Group handling functions for rendering group headers, descriptions, and collapse/expand state
   const getGroupDescription = (groupTitle: string) =>
     sortedDatasets.find(
-      (dataset) => getDatasetGroupTitle(dataset) === groupTitle,
+      (dataset) => getDatasetGroupLabel(dataset) === groupTitle,
     )?.groupDescription;
 
-  const getGroupExpanded = (groupTitle: string) =>
+  const isGroupExpanded = (groupTitle: string) =>
     isFilteringDatasets ||
     (expandedGroups[groupTitle] ?? groupTitle === selectedDatasetGroupTitle);
 
@@ -116,7 +115,7 @@ export default function DatasetSelect({
     }));
   };
 
-  const selectedDatasetId = selectedDataset ? selectedDataset.id : "";
+  const selectedDatasetId = selectedDataset?.id ?? "";
 
   const datasetSelectLabel = (
     <InputLabel shrink htmlFor="dataset-select">
@@ -139,7 +138,7 @@ export default function DatasetSelect({
         setIsFilteringDatasets(reason === "input" && inputValue.trim() !== "");
       }}
       getOptionLabel={getDatasetLabel}
-      groupBy={hasMultipleGroups ? getDatasetGroupTitle : undefined}
+      groupBy={hasMultipleGroups ? getDatasetGroupLabel : undefined}
       isOptionEqualToValue={(option, value) => option.id === value.id}
       disableClearable={!!selectedDataset}
       autoHighlight
@@ -152,13 +151,11 @@ export default function DatasetSelect({
       }}
       renderGroup={(params) => {
         const groupDescription = getGroupDescription(params.group);
-        const expanded = getGroupExpanded(params.group);
-        const groupListId = getDatasetGroupListId(params.group);
+        const expanded = isGroupExpanded(params.group);
         const groupTitle = (
           <ListItemButton
             dense
             aria-expanded={expanded}
-            aria-controls={groupListId}
             onMouseDown={(event) => event.preventDefault()}
             onClick={(event) => {
               event.stopPropagation();
@@ -202,9 +199,7 @@ export default function DatasetSelect({
               groupTitle
             )}
             <Collapse in={expanded} timeout="auto" unmountOnExit>
-              <ul id={groupListId} style={{ margin: 0, padding: 0 }}>
-                {params.children}
-              </ul>
+              <ul style={{ margin: 0, padding: 0 }}>{params.children}</ul>
             </Collapse>
           </li>
         );
@@ -282,10 +277,6 @@ function getDatasetLabel(dataset: Dataset | undefined) {
   }
   return dataset.title || dataset.id;
 }
-function getDatasetGroupTitle(dataset: Dataset) {
+function getDatasetGroupLabel(dataset: Dataset) {
   return dataset.groupTitle || i18n.get("Others");
-}
-
-function getDatasetGroupListId(groupTitle: string) {
-  return `dataset-select-group-${encodeURIComponent(groupTitle)}`;
 }

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -4,14 +4,13 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { ReactElement, useMemo } from "react";
+import { useMemo } from "react";
+import Autocomplete from "@mui/material/Autocomplete";
 import Divider from "@mui/material/Divider";
-import Input from "@mui/material/Input";
 import InputLabel from "@mui/material/InputLabel";
 import ListItemText from "@mui/material/ListItemText";
-import MenuItem from "@mui/material/MenuItem";
 import PushPinIcon from "@mui/icons-material/PushPin";
-import Select, { SelectChangeEvent } from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import TravelExploreIcon from "@mui/icons-material/TravelExplore";
@@ -48,47 +47,48 @@ export default function DatasetSelect({
   locateSelectedDataset,
 }: DatasetSelectProps) {
   const sortedDatasets = useMemo(() => {
-    return datasets.sort((dataset1: Dataset, dataset2: Dataset) => {
-      const groupOrder1 = dataset1.groupOrder ?? Infinity;
-      const groupOrder2 = dataset2.groupOrder ?? Infinity;
+    return [...(datasets || [])].sort(
+      (dataset1: Dataset, dataset2: Dataset) => {
+        const groupOrder1 = dataset1.groupOrder ?? Infinity;
+        const groupOrder2 = dataset2.groupOrder ?? Infinity;
 
-      if (groupOrder1 !== groupOrder2) {
-        return groupOrder1 - groupOrder2;
-      }
+        if (groupOrder1 !== groupOrder2) {
+          return groupOrder1 - groupOrder2;
+        }
 
-      const groupTitle1 = dataset1.groupTitle || "zzz";
-      const groupTitle2 = dataset2.groupTitle || "zzz";
-      const delta = groupTitle1.localeCompare(groupTitle2);
-      if (delta !== 0) {
-        return delta;
-      }
-      const sortValue1 = dataset1.sortValue;
-      const sortValue2 = dataset2.sortValue;
+        const groupTitle1 = dataset1.groupTitle || "zzz";
+        const groupTitle2 = dataset2.groupTitle || "zzz";
+        const delta = groupTitle1.localeCompare(groupTitle2);
+        if (delta !== 0) {
+          return delta;
+        }
+        const sortValue1 = dataset1.sortValue;
+        const sortValue2 = dataset2.sortValue;
 
-      // Handles when both sortValue are available
-      if (sortValue1 !== undefined && sortValue2 !== undefined) {
-        return sortValue1 - sortValue2;
-      }
+        // Handles when both sortValue are available
+        if (sortValue1 !== undefined && sortValue2 !== undefined) {
+          return sortValue1 - sortValue2;
+        }
 
-      // Handles when no sortValue is available
-      if (sortValue1 === undefined && sortValue2 === undefined) {
-        return dataset1.title.localeCompare(dataset2.title);
-      }
+        // Handles when no sortValue is available
+        if (sortValue1 === undefined && sortValue2 === undefined) {
+          return dataset1.title.localeCompare(dataset2.title);
+        }
 
-      // Handles when only one sortValue is available
-      return sortValue1 !== undefined ? -1 : 1;
-    });
+        // Handles when only one sortValue is available
+        return sortValue1 !== undefined ? -1 : 1;
+      },
+    );
   }, [datasets]);
 
-  const hasGroups = sortedDatasets.length > 0 && !!sortedDatasets[0].groupTitle;
+  const hasGroups = sortedDatasets.some((dataset) => !!dataset.groupTitle);
 
-  const handleDatasetChange = (event: SelectChangeEvent) => {
-    const datasetId = event.target.value || null;
-    selectDataset(datasetId, datasets, true);
-  };
+  const getGroupDescription = (groupTitle: string) =>
+    sortedDatasets.find(
+      (dataset) => getDatasetGroupTitle(dataset) === groupTitle,
+    )?.groupDescription;
 
   const selectedDatasetId = selectedDataset ? selectedDataset.id : "";
-  datasets = datasets || [];
 
   const datasetSelectLabel = (
     <InputLabel shrink htmlFor="dataset-select">
@@ -96,61 +96,71 @@ export default function DatasetSelect({
     </InputLabel>
   );
 
-  const items: ReactElement[] = [];
-  let lastGroupTitle: string | undefined;
-  sortedDatasets.forEach((dataset) => {
-    if (hasGroups) {
-      const groupTitle = dataset.groupTitle || i18n.get("Others");
-      const groupDescription = dataset.groupDescription;
-      if (groupTitle !== lastGroupTitle) {
-        const content = (
-          <Divider key={groupTitle}>
+  const datasetSelect = (
+    <Autocomplete
+      id="dataset-select"
+      options={sortedDatasets}
+      value={
+        sortedDatasets.find((dataset) => dataset.id === selectedDatasetId) ??
+        null
+      }
+      onChange={(_, dataset) => {
+        selectDataset(dataset?.id ?? null, datasets || [], true);
+      }}
+      getOptionLabel={getDatasetLabel}
+      groupBy={hasGroups ? getDatasetGroupTitle : undefined}
+      isOptionEqualToValue={(option, value) => option.id === value.id}
+      disableClearable={!!selectedDataset}
+      autoHighlight
+      blurOnSelect
+      sx={{
+        display: "inline-flex",
+        minWidth: 240,
+        mt: 2,
+        verticalAlign: "bottom",
+      }}
+      renderGroup={(params) => {
+        const groupDescription = getGroupDescription(params.group);
+        const groupTitle = (
+          <Divider sx={{ mx: 1, my: 0.5 }}>
             <Typography fontSize="small" color="text.secondary">
-              {groupTitle}
+              {params.group}
             </Typography>
           </Divider>
         );
-        items.push(
-          groupDescription ? (
-            <Tooltip arrow title={groupDescription}>
-              {content}
-            </Tooltip>
-          ) : (
-            content
-          ),
+
+        return (
+          <li key={params.key}>
+            {groupDescription ? (
+              <Tooltip arrow title={groupDescription}>
+                {groupTitle}
+              </Tooltip>
+            ) : (
+              groupTitle
+            )}
+            <ul style={{ margin: 0, padding: 0 }}>{params.children}</ul>
+          </li>
         );
-      }
-      lastGroupTitle = groupTitle;
-    }
-
-    items.push(
-      <MenuItem
-        key={dataset.id}
-        value={dataset.id}
-        selected={dataset.id === selectedDatasetId}
-      >
-        <ListItemText>{getDatasetLabel(dataset)} </ListItemText>
-        {dataset.id === selectedDataset2Id && (
-          <PushPinIcon fontSize="small" color="secondary" />
-        )}
-      </MenuItem>,
-    );
-  });
-
-  const datasetSelect = (
-    <Select
-      variant="standard"
-      value={selectedDatasetId}
-      onChange={handleDatasetChange}
-      input={<Input name="dataset" id="dataset-select" />}
-      displayEmpty
-      name="dataset"
-      renderValue={() =>
-        getDatasetLabel(datasets.find((d) => d.id === selectedDatasetId))
-      }
-    >
-      {items}
-    </Select>
+      }}
+      renderOption={({ key, ...props }, dataset) => (
+        <li key={key} {...props}>
+          <ListItemText>{getDatasetLabel(dataset)}</ListItemText>
+          {dataset.id === selectedDataset2Id && (
+            <PushPinIcon fontSize="small" color="secondary" />
+          )}
+        </li>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          inputProps={{
+            ...params.inputProps,
+            name: "dataset",
+          }}
+        />
+      )}
+    />
   );
 
   const rgbVisible =
@@ -197,4 +207,7 @@ function getDatasetLabel(dataset: Dataset | undefined) {
     return "?";
   }
   return dataset.title || dataset.id;
+}
+function getDatasetGroupTitle(dataset: Dataset) {
+  return dataset.groupTitle || i18n.get("Others");
 }

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -91,7 +91,7 @@ export default function DatasetSelect({
   const hasMultipleGroups =
     new Set(sortedDatasets.map(getDatasetGroupLabel)).size > 1;
 
-  // this where to set the threshold to decide whether to collapse groups by default or not
+  // Set threshold to decide whether to collapse groups by default or not
   const collapseGroupsByDefault = sortedDatasets.length > 10;
 
   const selectedDatasetGroupTitle = selectedDataset

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -49,9 +49,9 @@ export default function DatasetSelect({
   toggleDatasetRgbLayer,
   locateSelectedDataset,
 }: DatasetSelectProps) {
-  const [expandedGroups, setExpandedGroups] = useState<
-    Record<string, boolean>
-  >({});
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
+    {},
+  );
   const [isFilteringDatasets, setIsFilteringDatasets] = useState(false);
 
   const sortedDatasets = useMemo(() => {
@@ -89,7 +89,8 @@ export default function DatasetSelect({
     );
   }, [datasets]);
 
-  const hasGroups = sortedDatasets.some((dataset) => !!dataset.groupTitle);
+  const hasMultipleGroups =
+    new Set(sortedDatasets.map(getDatasetGroupTitle)).size > 1;
 
   const selectedDatasetGroupTitle = selectedDataset
     ? getDatasetGroupTitle(selectedDataset)
@@ -138,7 +139,7 @@ export default function DatasetSelect({
         setIsFilteringDatasets(reason === "input" && inputValue.trim() !== "");
       }}
       getOptionLabel={getDatasetLabel}
-      groupBy={hasGroups ? getDatasetGroupTitle : undefined}
+      groupBy={hasMultipleGroups ? getDatasetGroupTitle : undefined}
       isOptionEqualToValue={(option, value) => option.id === value.id}
       disableClearable={!!selectedDataset}
       autoHighlight
@@ -214,7 +215,7 @@ export default function DatasetSelect({
           {...props}
           style={{
             ...props.style,
-            ...(hasGroups ? { paddingLeft: 32 } : {}),
+            ...(hasMultipleGroups ? { paddingLeft: 32 } : {}),
           }}
         >
           <ListItemText>{getDatasetLabel(dataset)}</ListItemText>

--- a/src/components/DatasetSelect.tsx
+++ b/src/components/DatasetSelect.tsx
@@ -4,10 +4,13 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Autocomplete from "@mui/material/Autocomplete";
-import Divider from "@mui/material/Divider";
+import Collapse from "@mui/material/Collapse";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import InputLabel from "@mui/material/InputLabel";
+import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import PushPinIcon from "@mui/icons-material/PushPin";
 import TextField from "@mui/material/TextField";
@@ -46,6 +49,11 @@ export default function DatasetSelect({
   toggleDatasetRgbLayer,
   locateSelectedDataset,
 }: DatasetSelectProps) {
+  const [expandedGroups, setExpandedGroups] = useState<
+    Record<string, boolean>
+  >({});
+  const [isFilteringDatasets, setIsFilteringDatasets] = useState(false);
+
   const sortedDatasets = useMemo(() => {
     return [...(datasets || [])].sort(
       (dataset1: Dataset, dataset2: Dataset) => {
@@ -83,10 +91,29 @@ export default function DatasetSelect({
 
   const hasGroups = sortedDatasets.some((dataset) => !!dataset.groupTitle);
 
+  const selectedDatasetGroupTitle = selectedDataset
+    ? getDatasetGroupTitle(selectedDataset)
+    : undefined;
+
   const getGroupDescription = (groupTitle: string) =>
     sortedDatasets.find(
       (dataset) => getDatasetGroupTitle(dataset) === groupTitle,
     )?.groupDescription;
+
+  const getGroupExpanded = (groupTitle: string) =>
+    isFilteringDatasets ||
+    (expandedGroups[groupTitle] ?? groupTitle === selectedDatasetGroupTitle);
+
+  const toggleGroupExpanded = (groupTitle: string) => {
+    setExpandedGroups((currentExpandedGroups) => ({
+      ...currentExpandedGroups,
+      [groupTitle]: !(
+        isFilteringDatasets ||
+        (currentExpandedGroups[groupTitle] ??
+          groupTitle === selectedDatasetGroupTitle)
+      ),
+    }));
+  };
 
   const selectedDatasetId = selectedDataset ? selectedDataset.id : "";
 
@@ -107,6 +134,9 @@ export default function DatasetSelect({
       onChange={(_, dataset) => {
         selectDataset(dataset?.id ?? null, datasets || [], true);
       }}
+      onInputChange={(_, inputValue, reason) => {
+        setIsFilteringDatasets(reason === "input" && inputValue.trim() !== "");
+      }}
       getOptionLabel={getDatasetLabel}
       groupBy={hasGroups ? getDatasetGroupTitle : undefined}
       isOptionEqualToValue={(option, value) => option.id === value.id}
@@ -121,12 +151,44 @@ export default function DatasetSelect({
       }}
       renderGroup={(params) => {
         const groupDescription = getGroupDescription(params.group);
+        const expanded = getGroupExpanded(params.group);
+        const groupListId = getDatasetGroupListId(params.group);
         const groupTitle = (
-          <Divider sx={{ mx: 1, my: 0.5 }}>
+          <ListItemButton
+            dense
+            aria-expanded={expanded}
+            aria-controls={groupListId}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleGroupExpanded(params.group);
+            }}
+            sx={{
+              mx: 1,
+              my: 0.5,
+              minHeight: 28,
+              px: 0.75,
+              py: 0,
+              color: "text.secondary",
+              "&::before, &::after": {
+                content: '""',
+                borderTop: 1,
+                borderColor: "divider",
+                flex: 1,
+              },
+              "&::before": { mr: 1 },
+              "&::after": { ml: 1 },
+            }}
+          >
             <Typography fontSize="small" color="text.secondary">
               {params.group}
             </Typography>
-          </Divider>
+            {expanded ? (
+              <ExpandLessIcon fontSize="small" sx={{ ml: 0.25 }} />
+            ) : (
+              <ExpandMoreIcon fontSize="small" sx={{ ml: 0.25 }} />
+            )}
+          </ListItemButton>
         );
 
         return (
@@ -138,12 +200,23 @@ export default function DatasetSelect({
             ) : (
               groupTitle
             )}
-            <ul style={{ margin: 0, padding: 0 }}>{params.children}</ul>
+            <Collapse in={expanded} timeout="auto" unmountOnExit>
+              <ul id={groupListId} style={{ margin: 0, padding: 0 }}>
+                {params.children}
+              </ul>
+            </Collapse>
           </li>
         );
       }}
       renderOption={({ key, ...props }, dataset) => (
-        <li key={key} {...props}>
+        <li
+          key={key}
+          {...props}
+          style={{
+            ...props.style,
+            ...(hasGroups ? { paddingLeft: 32 } : {}),
+          }}
+        >
           <ListItemText>{getDatasetLabel(dataset)}</ListItemText>
           {dataset.id === selectedDataset2Id && (
             <PushPinIcon fontSize="small" color="secondary" />
@@ -210,4 +283,8 @@ function getDatasetLabel(dataset: Dataset | undefined) {
 }
 function getDatasetGroupTitle(dataset: Dataset) {
   return dataset.groupTitle || i18n.get("Others");
+}
+
+function getDatasetGroupListId(groupTitle: string) {
+  return `dataset-select-group-${encodeURIComponent(groupTitle)}`;
 }


### PR DESCRIPTION
Combining <Autocomplete/>` component for text search and a grouped select dropdown to choose desired datasets. Added multiple cases to StoryBook.
Current behaviour: If amount of datasets is below 10, all groups are expanded. If 10 or above, all are collapsed despite the groups that hold a selected dataset. When text input via keyboard all groups are expanded.
closes #550 