### PR TITLE
fix(TimeSeriesPanel): constrain tooltip width to prevent clipping

### DIFF
--- a/src/components/TimeSeriesPanel/CustomTooltip.tsx
+++ b/src/components/TimeSeriesPanel/CustomTooltip.tsx
@@ -20,6 +20,8 @@ const styles = makeStyles({
     border: "2px solid black",
     borderRadius: theme.spacing(2),
     padding: theme.spacing(1.5),
+    maxWidth: theme.spacing(40),
+    overflowWrap: "break-word",
   }),
   toolTipValue: {
     fontWeight: "bold",


### PR DESCRIPTION
## Summary

The chart tooltip in the TimeSeriesPanel becomes too wide when displaying many time series or long labels, causing it to be clipped at the edge of the chart area (see #619).

## Root cause

The \"CustomTooltip\" component did not set any \"maxWidth\" constraint on its container, so the tooltip would grow indefinitely to fit all content, eventually exceeding the chart boundaries and getting clipped by the viewport or parent container.

## Changes

- Added \"maxWidth: theme.spacing(40)\" to the tooltip container style in \"CustomTooltip.tsx\".
- Added \"overflowWrap: \"break-word\"\" so long labels wrap cleanly within the constrained width.

## Testing

- \"npm run compile\" — passes
- \"npm run lint\" — passes
- \"npx vitest run\" — 95/95 tests pass

Fixes #619