### PR TITLE
fix(TimeSeriesPanel): keep chart visible with many legend items

### DIFF
--- a/src/components/TimeSeriesPanel/CustomLegend.tsx
+++ b/src/components/TimeSeriesPanel/CustomLegend.tsx
@@ -12,12 +12,14 @@ import { makeStyles } from "@/util/styles";
 import Box from "@mui/material/Box";
 
 const styles = makeStyles({
-  legendContainer: {
+  legendContainer: (theme) => ({
     display: "flex",
     justifyContent: "center",
     columnGap: "12px",
     flexWrap: "wrap",
-  },
+    maxHeight: theme.spacing(7),
+    overflowY: "auto",
+  }),
   legendItem: {
     display: "flex",
     alignItems: "center",


### PR DESCRIPTION
## Summary

When many places are added to a time-series chart, the custom legend can wrap across many rows and consume the chart area. This keeps the chart layout stable by bounding the legend height and allowing the legend entries to scroll vertically.

## Root cause

Each added place creates another legend entry. The custom legend used unrestricted wrapping, so a large number of entries could grow vertically without limit and push the plotted chart area out of view.

## Changes

- Converts the custom legend container style to use the MUI theme.
- Adds a bounded legend height with vertical scrolling once many legend entries are present.

## Testing

- `npm run compile` — passes
- `npm run lint` — passes
- `npx vitest run` — 95/95 tests pass
- `npm run build` — passes

## Manual verification note

I validated the layout path in source and with the production build. A full browser reproduction with real many-place time-series data requires the documented xcube demo backend/data setup, so I did not claim a live visual reproduction.

Fixes #618