### PR TITLE
Fix tooltip width

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,0 +1,9 @@
+const tooltipStyles = {
+  position: 'absolute',
+  backgroundColor: 'white',
+  border: '1px solid black',
+  padding: '10px',
+  maxWidth: '80%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+};


### PR DESCRIPTION
## What was broken
The chart tooltip becomes too wide and is partly cut off at the edge.
## What changed
The tooltip width is adjusted to stay within the chart area.
## How to test
Run the application and hover over the chart to verify the tooltip is fully visible.

---
_Opened by autonomous agent. Human review required before merge._