### PR TITLE
reset application

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -6,7 +6,9 @@
 
 import React from "react";
 import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import ListItemText from "@mui/material/ListItemText";
 import Menu from "@mui/material/Menu";
@@ -34,6 +36,7 @@ import SettingsPanel from "./SettingsPanel";
 import SettingsSubPanel from "./SettingsSubPanel";
 import ToggleSetting from "./ToggleSetting";
 import RadioSetting from "./RadioSetting";
+import { resetApplicationData } from "@/util/storage";
 
 const styles: Record<string, SxProps<Theme>> = {
   textField: (theme) => ({
@@ -103,6 +106,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const [timeChunkSize, setTimeChunkSize] = React.useState(
     settings.timeChunkSize + "",
   );
+  const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
   const theme = useTheme();
 
   React.useEffect(() => {
@@ -217,6 +221,11 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     updateSettings({
       themeMode: event.target.value as ThemeMode,
     });
+  }
+
+  async function handleResetApplication() {
+    await resetApplicationData();
+    window.location.reload();
   }
 
   return (
@@ -458,6 +467,17 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
             </SettingsSubPanel>
           </SettingsPanel>
 
+          <SettingsPanel title={i18n.get("Reset application")}>
+            <SettingsSubPanel
+              label={i18n.get("Reset application")}
+              value={i18n.get("Remove all stored data and reload")}
+            >
+              <Button color="error" onClick={() => setResetDialogOpen(true)}>
+                {i18n.get("Reset")}
+              </Button>
+            </SettingsSubPanel>
+          </SettingsPanel>
+
           <SettingsPanel title={i18n.get("System Information")}>
             <SettingsSubPanel
               label={`xcube Viewer ${i18n.get("version")}`}
@@ -473,6 +493,31 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
             />
           </SettingsPanel>
         </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={resetDialogOpen}
+        onClose={() => setResetDialogOpen(false)}
+        aria-labelledby="reset-application-dialog-title"
+      >
+        <DialogTitle id="reset-application-dialog-title">
+          {i18n.get("Reset application")}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {i18n.get(
+              "This removes all locally stored data, including settings, and reloads the application. This cannot be undone.",
+            )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetDialogOpen(false)}>
+            {i18n.get("Cancel")}
+          </Button>
+          <Button color="error" onClick={handleResetApplication} autoFocus>
+            {i18n.get("Reset")}
+          </Button>
+        </DialogActions>
       </Dialog>
 
       <Menu

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -181,6 +181,26 @@
       "se": "Systeminformation"
     },
     {
+      "en": "Reset application",
+      "de": "Anwendung zurücksetzen",
+      "se": "Återställ applikationen"
+    },
+    {
+      "en": "Remove all stored data and reload",
+      "de": "Alle gespeicherten Daten entfernen und neu laden",
+      "se": "Ta bort all sparad data och ladda om"
+    },
+    {
+      "en": "Reset",
+      "de": "Zurücksetzen",
+      "se": "Återställ"
+    },
+    {
+      "en": "This removes all locally stored data, including settings, and reloads the application. This cannot be undone.",
+      "de": "Dies entfernt alle lokal gespeicherten Daten einschließlich Einstellungen und lädt die Anwendung neu. Dies kann nicht rückgängig gemacht werden.",
+      "se": "Detta tar bort all lokalt sparad data, inklusive inställningar, och laddar om applikationen. Detta kan inte ångras."
+    },
+    {
       "en": "version",
       "de": "Version",
       "se": "Version"
@@ -1355,7 +1375,7 @@
       "de": "Permalink in die Zwischenablage kopiert",
       "se": "Permalink kopieras till klippbordet"
     },
-     {
+    {
       "en": "Permalink copied to clipboard (expires in ${expiration} days)",
       "de": "Permalink in die Zwischenablage kopiert (läuft ab in ${expiration} Tagen)",
       "se": "Permalink kopieras till klippbordet (går ut om ${expiration} dagar)"

--- a/src/util/storage.test.ts
+++ b/src/util/storage.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetApplicationData } from "./storage";
+
+describe("resetApplicationData", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("clears browser storage, caches, and service-worker registrations", async () => {
+    const deleteCache = vi.fn().mockResolvedValue(true);
+    const unregister = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal("caches", {
+      keys: vi.fn().mockResolvedValue(["viewer-cache"]),
+      delete: deleteCache,
+    });
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistrations: vi.fn().mockResolvedValue([{ unregister }]),
+      },
+    });
+    window.localStorage.setItem("setting", "value");
+    window.sessionStorage.setItem("session", "value");
+
+    await resetApplicationData();
+
+    expect(window.localStorage.length).toBe(0);
+    expect(window.sessionStorage.length).toBe(0);
+    expect(deleteCache).toHaveBeenCalledWith("viewer-cache");
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+});

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -18,6 +18,57 @@ export function getLocalStorage(brandingName: string): Storage | null {
   return _getStorage("localStorage", brandingName);
 }
 
+/**
+ * Removes browser data that may keep this viewer instance from starting with
+ * its default state. HttpOnly cookies cannot be removed from JavaScript.
+ */
+export async function resetApplicationData(): Promise<void> {
+  try {
+    window.localStorage.clear();
+  } catch (_e) {
+    // Storage may be unavailable, for example when it is disabled by the user.
+  }
+
+  try {
+    window.sessionStorage.clear();
+  } catch (_e) {
+    // Storage may be unavailable, for example when it is disabled by the user.
+  }
+
+  clearCookies();
+
+  try {
+    if ("caches" in window) {
+      const cacheNames = await window.caches.keys();
+      await Promise.all(
+        cacheNames.map((cacheName) => window.caches.delete(cacheName)),
+      );
+    }
+  } catch (_e) {
+    // The Cache API is optional and may be unavailable in private browsing.
+  }
+
+  try {
+    if ("serviceWorker" in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(
+        registrations.map((registration) => registration.unregister()),
+      );
+    }
+  } catch (_e) {
+    // Service workers are optional and can be unavailable for this origin.
+  }
+}
+
+function clearCookies(): void {
+  document.cookie.split(";").forEach((cookie) => {
+    const cookieName = cookie.split("=", 1)[0].trim();
+    if (cookieName) {
+      document.cookie = `${cookieName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+  });
+}
+
 function _getStorage(
   type: "localStorage" | "sessionStorage",
   brandingName: string,


### PR DESCRIPTION
Adds a reset function to restore an xcube Viewer instance to a clean state.
The new Settings → Reset application action asks for confirmation, then clears browser-held viewer data and reloads the app.
Closes #626.

- Clear local and session storage
- Remove JavaScript-accessible cookies
- Delete Cache API entries
- Reload after reset completes