### PR TITLE
improve time-series export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changes in version 1.7.4 (in development)
 
+### Improvements
+
+* Improved time-series data export: Text/CSV and GeoJSON exports now include
+  place identifiers, spatial information, and values in one file. Users can
+  export the full or currently displayed time range, or export place geometries
+  only. (#300)
+
 ### Other changes
 
 * Updated dependencies. Now using

--- a/docs/features.md
+++ b/docs/features.md
@@ -1982,26 +1982,34 @@ A list of all the features that the viewer contains will be created here, in whi
 				in the header of the Viewer and select options for export:
 				<ul>
 					<li>
-						<strong>Include time series data</strong> (file format:
-						<code>.txt</code>)
+						<strong>Data</strong>: time-series data with place information,
+						or place geometries only
 					</li>
 					<li>
-						<strong>Separator</strong> for time series data (default:
-						<code>,</code>)
+						<strong>Export format</strong>: Text/CSV or GeoJSON
 					</li>
 					<li>
-						<strong>Include place data</strong> (file format:
-						<code>.geojson</code>)
+						<strong>Time range</strong>: the full time series or the range
+						currently displayed in the chart
 					</li>
-					<li><strong>Combine place data</strong> into a single file</li>
-					<li>Export as a <strong>ZIP archive</strong></li>
+					<li>
+						<strong>Separator</strong> for Text/CSV exports (default:
+						<code>TAB</code>)
+					</li>
+					<li>
+						<strong>Compress as ZIP</strong>: optionally wraps the single
+						export file in a ZIP archive
+					</li>
 					<li><strong>Filename</strong> configuration</li>
 				</ul>
 			</td>
 		</tr>
 		<tr>
 			<td><b>Aim</b></td>
-			<td>To export places and/or time series created within the Viewer.</td>
+			<td>
+				To export time-series values together with place identifiers and
+				spatial information in one file, or to export place geometries.
+			</td>
 		</tr>
 		<tr>
 			<td colspan="2">

--- a/docs/user_guide/analyse.md
+++ b/docs/user_guide/analyse.md
@@ -38,10 +38,18 @@ There are multiple options to explore the graph:
 
 #### Export time series
 
-Export the time series using the option in the header at the top right. You have the option to export the time series, the geometries of the places, or both.
+Export time series using the option in the header at the top right. Select either
+Text/CSV or GeoJSON format. Both formats include the place identifier, spatial
+information, and time-series values in one file. Text/CSV exports provide
+longitude and latitude for point places and a GeoJSON geometry column for every
+place geometry. GeoJSON exports contain one feature per time series, including
+its geometry and values.
 
-![Export](../assets/images/analysis_timeseries_export.png)
+Choose whether to export the full time series or only the time range currently
+displayed in the chart. You can also export the visible place geometries without
+time-series values as a GeoJSON file.
 
+Select **Compress as ZIP** to wrap the single export file in a ZIP archive.
 ### Statistics
 
 Compute and display basic statistics for the currently [selected variable](../concepts.md/#selected-variable), [selected timestamp](../concepts.md/#selected-time), and [selected place](../concepts.md/#selected-place). To obtain the statistics select a place and compute by using the $\Sigma$ -icon next to the variables drop-down menu or use the `+`-icon under the Statistics Tab in the sidebar.
@@ -216,6 +224,7 @@ Modify both the color and opacity of a [place](../concepts.md/#places-and-place-
 
 ### Export
 
-The geometry of [places](../concepts.md/#places-and-place-groups) created in the Viewer can be exported. This feature can be enabled during [the export of time series](#export-time-series). To include the geometry information in the export, it must be explicitly selected.
-
-![Export](../assets/images/analysis_timeseries_export.png)
+The geometry of [places](../concepts.md/#places-and-place-groups) created in the
+Viewer can be exported as a single GeoJSON file. When exporting time series,
+place identifiers and spatial information are included automatically in the
+selected export format.

--- a/src/actions/dataActions.test.ts
+++ b/src/actions/dataActions.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { PlaceGroup } from "@/model/place";
+import { TimeSeriesGroup } from "@/model/timeSeries";
+import JSZip from "jszip";
+
+import { createExportArchive, createExportFile } from "@/model/dataExport";
+
+const firstTime = Date.parse("2024-01-01T00:00:00Z");
+const secondTime = Date.parse("2024-01-02T00:00:00Z");
+
+const placeGroups: PlaceGroup[] = [
+  {
+    id: "places",
+    title: "Places",
+    type: "FeatureCollection",
+    features: [
+      {
+        id: "point-1",
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [12.5, 48.1] },
+        properties: {},
+      },
+    ],
+  },
+];
+
+const timeSeriesGroups: TimeSeriesGroup[] = [
+  {
+    id: "group",
+    timeSeriesArray: [
+      {
+        source: {
+          datasetId: "dataset",
+          datasetTitle: "Dataset",
+          variableName: "temperature",
+          placeId: "point-1",
+          geometry: { type: "Point", coordinates: [12.5, 48.1] },
+          valueDataKey: "mean",
+          errorDataKey: null,
+        },
+        data: [
+          { time: firstTime, countTot: 1, mean: 280 },
+          { time: secondTime, countTot: 1, mean: 281 },
+        ],
+      },
+    ],
+  },
+];
+
+describe("createExportFile", () => {
+  it("creates one text file containing place information and values", () => {
+    const exportFile = createExportFile(timeSeriesGroups, placeGroups, {
+      dataType: "timeSeries",
+      format: "text",
+      timeRange: null,
+      separator: "TAB",
+      fileName: "series",
+    });
+
+    expect(exportFile.fileName).toBe("series.txt");
+    expect(exportFile.contentType).toBe("text/plain;charset=utf-8");
+    expect(exportFile.content).toContain(
+      "placeId\tlongitude\tlatitude\tgeometry\ttime\tdataset.temperature.mean",
+    );
+    expect(exportFile.content).toContain(
+      'point-1\t12.5\t48.1\t"{""type"":""Point"",""coordinates"":[12.5,48.1]}"\t2024-01-01 00:00:00\t280',
+    );
+  });
+
+  it("creates one filtered GeoJSON time-series file", () => {
+    const exportFile = createExportFile(timeSeriesGroups, placeGroups, {
+      dataType: "timeSeries",
+      format: "geojson",
+      timeRange: [secondTime, secondTime],
+      separator: "TAB",
+      fileName: "series",
+    });
+
+    expect(exportFile.fileName).toBe("series.geojson");
+    expect(exportFile.contentType).toBe("application/geo+json;charset=utf-8");
+    expect(JSON.parse(exportFile.content)).toMatchObject({
+      type: "FeatureCollection",
+      features: [
+        {
+          geometry: { type: "Point", coordinates: [12.5, 48.1] },
+          properties: {
+            placeId: "point-1",
+            data: [{ time: "2024-01-02 00:00:00", mean: 281 }],
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps the places-only export as one GeoJSON file", () => {
+    const exportFile = createExportFile([], placeGroups, {
+      dataType: "places",
+      format: "text",
+      timeRange: null,
+      separator: "TAB",
+      fileName: "places",
+    });
+
+    expect(exportFile.fileName).toBe("places.geojson");
+    expect(JSON.parse(exportFile.content)).toEqual({
+      type: "FeatureCollection",
+      features: placeGroups[0].features,
+    });
+  });
+
+  it("wraps exactly the generated export file when ZIP compression is selected", async () => {
+    const exportFile = createExportFile(timeSeriesGroups, placeGroups, {
+      dataType: "timeSeries",
+      format: "text",
+      timeRange: null,
+      separator: "TAB",
+      fileName: "series",
+    });
+
+    const archive = await JSZip.loadAsync(
+      await createExportArchive(exportFile),
+    );
+
+    expect(Object.keys(archive.files)).toEqual(["series.txt"]);
+    await expect(archive.file("series.txt")!.async("string")).resolves.toBe(
+      exportFile.content,
+    );
+  });
+});

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -6,7 +6,6 @@
 
 import { Action, Dispatch, Store } from "redux";
 import * as geojson from "geojson";
-import JSZip from "jszip";
 import { saveAs } from "file-saver";
 
 import * as api from "@/api";
@@ -24,11 +23,12 @@ import {
 import { getUserPlacesFromCsv } from "@/model/user-place/csv";
 import { getUserPlacesFromGeoJson } from "@/model/user-place/geojson";
 import { getUserPlacesFromWkt } from "@/model/user-place/wkt";
+import { TimeSeries } from "@/model/timeSeries";
 import {
-  TimeSeries,
-  TimeSeriesGroup,
-  timeSeriesGroupsToTable,
-} from "@/model/timeSeries";
+  createExportArchive,
+  createExportFile,
+  ExportFile,
+} from "@/model/dataExport";
 import { initializeExtensions } from "@/ext/actions";
 import {
   mapProjectionSelector,
@@ -1093,17 +1093,17 @@ export function exportData() {
     getState: () => AppState,
   ) => {
     const {
-      exportTimeSeries,
+      exportDataType,
+      exportFormat,
+      exportTimeRange,
+      exportAsZipArchive,
       exportTimeSeriesSeparator,
-      exportPlaces,
-      exportPlacesAsCollection,
-      exportZipArchive,
       exportFileName,
+      selectedTimeRange,
     } = getState().controlState;
 
-    let placeGroups: PlaceGroup[] = [];
-
-    if (exportTimeSeries) {
+    let placeGroups: PlaceGroup[];
+    if (exportDataType === "timeSeries") {
       // Time series may reference any place, so collect all known place groups.
       placeGroups = [];
       const datasets = datasetsSelector(getState());
@@ -1113,188 +1113,43 @@ export function exportData() {
         }
       });
       placeGroups = [...placeGroups, ...userPlaceGroupsSelector(getState())];
-    } else if (exportPlaces) {
+    } else {
       // Just export all visible places.
       placeGroups = selectedPlaceGroupsSelector(getState());
     }
 
-    _exportData(getState().dataState.timeSeriesGroups, placeGroups, {
-      includeTimeSeries: exportTimeSeries,
-      includePlaces: exportPlaces,
-      separator: exportTimeSeriesSeparator,
-      placesAsCollection: exportPlacesAsCollection,
-      zip: exportZipArchive,
-      fileName: exportFileName,
-    });
+    const exportFile = createExportFile(
+      getState().dataState.timeSeriesGroups,
+      placeGroups,
+      {
+        dataType: exportDataType,
+        format: exportFormat,
+        timeRange: exportTimeRange === "displayed" ? selectedTimeRange : null,
+        separator: exportTimeSeriesSeparator,
+        fileName: exportFileName,
+      },
+    );
+    if (exportAsZipArchive) {
+      downloadArchive(`${exportFileName || "export"}.zip`, exportFile);
+    } else {
+      downloadFile(
+        exportFile.fileName,
+        exportFile.content,
+        exportFile.contentType,
+      );
+    }
   };
 }
 
-abstract class Exporter {
-  abstract write(path: string, content: string): void;
-
-  abstract close(): void;
+function downloadArchive(archiveFileName: string, exportFile: ExportFile) {
+  void createExportArchive(exportFile).then((archive) =>
+    saveAs(archive, archiveFileName),
+  );
 }
 
-class ZipExporter extends Exporter {
-  fileName: string;
-  zipArchive: JSZip;
-
-  constructor(fileName: string) {
-    super();
-    this.fileName = fileName;
-    this.zipArchive = new JSZip();
-  }
-
-  write(path: string, content: string) {
-    this.zipArchive.file(path, content);
-  }
-
-  close() {
-    this.zipArchive
-      .generateAsync({ type: "blob" })
-      .then((content) => saveAs(content, this.fileName));
-  }
+function downloadFile(fileName: string, content: string, type: string) {
+  saveAs(new Blob([content], { type }), fileName);
 }
-
-class FileExporter extends Exporter {
-  write(path: string, content: string) {
-    const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
-    saveAs(blob, path);
-  }
-
-  close() {}
-}
-
-interface ExportOptions {
-  includeTimeSeries?: boolean;
-  separator?: string;
-  includePlaces?: boolean;
-  fileName?: string;
-  placesAsCollection?: boolean;
-  zip?: boolean;
-}
-
-function _exportData(
-  timeSeriesGroups: TimeSeriesGroup[],
-  placeGroups: PlaceGroup[],
-  options: ExportOptions,
-) {
-  const { includeTimeSeries, includePlaces, placesAsCollection, zip } = options;
-
-  let { separator, fileName } = options;
-
-  separator = separator || "TAB";
-  if (separator.toUpperCase() === "TAB") {
-    separator = "\t";
-  }
-
-  fileName = fileName || "export";
-
-  if (!includeTimeSeries && !includePlaces) {
-    return;
-  }
-
-  let exporter: Exporter;
-  if (zip) {
-    exporter = new ZipExporter(`${fileName}.zip`);
-  } else {
-    exporter = new FileExporter();
-  }
-
-  let placesToExport: { [placeId: string]: Place };
-
-  if (includeTimeSeries) {
-    const { colNames, dataRows, referencedPlaces } = timeSeriesGroupsToTable(
-      timeSeriesGroups,
-      placeGroups,
-    );
-    const validTypes: { [typeName: string]: boolean } = {
-      number: true,
-      string: true,
-    };
-    const csvHeaderRow = colNames.join(separator);
-    const csvDataRows = dataRows.map((row) =>
-      row
-        .map((value) => (validTypes[typeof value] ? value + "" : ""))
-        .join(separator),
-    );
-    const csvText = [csvHeaderRow].concat(csvDataRows).join("\n");
-    exporter.write(`${fileName}.txt`, csvText);
-    placesToExport = referencedPlaces;
-  } else {
-    placesToExport = {};
-    placeGroups.forEach((placeGroup) => {
-      if (placeGroup.features) {
-        placeGroup.features.forEach((place) => {
-          placesToExport[place.id] = place;
-        });
-      }
-    });
-  }
-
-  if (includePlaces) {
-    if (placesAsCollection) {
-      const collection = {
-        type: "FeatureCollection",
-        features: Object.keys(placesToExport).map(
-          (placeId) => placesToExport![placeId],
-        ),
-      };
-      exporter.write(
-        `${fileName}.geojson`,
-        JSON.stringify(collection, null, 2),
-      );
-    } else {
-      Object.keys(placesToExport).forEach((placeId) => {
-        exporter.write(
-          `${placeId}.geojson`,
-          JSON.stringify(placesToExport![placeId], null, 2),
-        );
-      });
-    }
-  }
-
-  exporter.close();
-}
-
-/*
-function _downloadTimeSeriesGeoJSON(timeSeriesGroups: TimeSeriesGroup[],
-                                    placeGroups: PlaceGroup[],
-                                    format: 'GeoJSON' | 'CSV',
-                                    fileName: string = 'time-series',
-                                    multiFile: boolean = true,
-                                    zipArchive: boolean = true) {
-    const featureCollection = timeSeriesGroupsToGeoJSON(timeSeriesGroups);
-
-    if (format === 'GeoJSON') {
-        if (zipArchive) {
-            const zip = new JSZip();
-            if (multiFile) {
-                zip.file(`${fileName}.geojson`,
-                         JSON.stringify(featureCollection, null, 2));
-            } else {
-                for (let feature of featureCollection.features) {
-                    zip.file(`${feature.id}.geojson`,
-                             JSON.stringify(feature, null, 2));
-                }
-            }
-            zip.generateAsync({type: "blob"})
-               .then((content) => saveAs(content, `${fileName}.zip`));
-        } else {
-            if (multiFile) {
-                throw new Error('Cannot download multi-file exports');
-            }
-            const blob = new Blob([JSON.stringify(featureCollection, null, 2)],
-                                  {type: "text/plain;charset=utf-8"});
-            saveAs(blob, `${fileName}.geojson`);
-        }
-    } else {
-        // TODO (forman): implement CSV export
-        throw new Error(`Download as ${format} is not yet implemented`);
-    }
-
-}
-*/
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/components/ExportDialog.test.tsx
+++ b/src/components/ExportDialog.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ControlState } from "@/states/controlState";
+import ExportDialog from "./ExportDialog";
+
+afterEach(cleanup);
+
+function createSettings(settings: Partial<ControlState> = {}): ControlState {
+  return {
+    exportDataType: "timeSeries",
+    exportFormat: "text",
+    exportTimeRange: "full",
+    exportAsZipArchive: false,
+    exportTimeSeriesSeparator: "TAB",
+    exportFileName: "export",
+    ...settings,
+  } as ControlState;
+}
+
+interface ExportDialogHarnessProps {
+  initialSettings?: Partial<ControlState>;
+  closeDialog?: (dialogId: string) => void;
+  downloadData?: () => void;
+}
+
+function ExportDialogHarness({
+  initialSettings,
+  closeDialog = vi.fn(),
+  downloadData = vi.fn(),
+}: ExportDialogHarnessProps) {
+  const [settings, setSettings] = useState(createSettings(initialSettings));
+  return (
+    <ExportDialog
+      open={true}
+      closeDialog={closeDialog}
+      settings={settings}
+      updateSettings={(updates) =>
+        setSettings((currentSettings) => ({ ...currentSettings, ...updates }))
+      }
+      downloadData={downloadData}
+    />
+  );
+}
+
+describe("ExportDialog", () => {
+  it("uses a single explicit text-format selection by default", () => {
+    render(<ExportDialogHarness />);
+
+    expect(screen.getByRole("radio", { name: "Text/CSV" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "GeoJSON" })).not.toBeChecked();
+    expect(screen.getByDisplayValue("TAB")).toBeEnabled();
+    expect(
+      screen.getByRole("radio", { name: "Full time series" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Compress as ZIP" }),
+    ).not.toBeChecked();
+  });
+
+  it("hides text-only options for GeoJSON exports", () => {
+    render(<ExportDialogHarness />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "GeoJSON" }));
+
+    expect(screen.getByRole("radio", { name: "GeoJSON" })).toBeChecked();
+    expect(screen.queryByDisplayValue("TAB")).not.toBeInTheDocument();
+  });
+
+  it("uses the full time series when no displayed range is available", () => {
+    render(
+      <ExportDialogHarness
+        initialSettings={{
+          exportTimeRange: "displayed",
+          selectedTimeRange: null,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Full time series" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "Displayed time range" }),
+    ).toBeDisabled();
+  });
+
+  it("keeps places-only exports in GeoJSON and hides time-range controls", () => {
+    render(<ExportDialogHarness />);
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Place geometries only" }),
+    );
+
+    expect(screen.getByRole("radio", { name: "GeoJSON" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Text/CSV" })).toBeDisabled();
+    expect(
+      screen.queryByRole("radio", { name: "Full time series" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("allows ZIP compression to be selected explicitly", () => {
+    render(<ExportDialogHarness />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Compress as ZIP" }));
+
+    expect(
+      screen.getByRole("checkbox", { name: "Compress as ZIP" }),
+    ).toBeChecked();
+  });
+
+  it("downloads only when the file name and active options are valid", () => {
+    const closeDialog = vi.fn();
+    const downloadData = vi.fn();
+    render(
+      <ExportDialogHarness
+        initialSettings={{ exportFileName: "invalid name" }}
+        closeDialog={closeDialog}
+        downloadData={downloadData}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Download" })).toBeDisabled();
+
+    fireEvent.change(screen.getByDisplayValue("invalid name"), {
+      target: { value: "export" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(closeDialog).toHaveBeenCalledWith("export");
+    expect(downloadData).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ExportDialog.test.tsx
+++ b/src/components/ExportDialog.test.tsx
@@ -92,15 +92,19 @@ describe("ExportDialog", () => {
     ).toBeDisabled();
   });
 
-  it("keeps places-only exports in GeoJSON and hides time-range controls", () => {
+  it("keeps places-only exports in GeoJSON and removes inapplicable options", () => {
     render(<ExportDialogHarness />);
 
     fireEvent.click(
       screen.getByRole("radio", { name: "Place geometries only" }),
     );
 
-    expect(screen.getByRole("radio", { name: "GeoJSON" })).toBeChecked();
-    expect(screen.getByRole("radio", { name: "Text/CSV" })).toBeDisabled();
+    expect(
+      screen.queryByRole("radio", { name: "Text/CSV" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Place geometries are exported as GeoJSON."),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("radio", { name: "Full time series" }),
     ).not.toBeInTheDocument();

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -10,13 +10,15 @@ import Checkbox from "@mui/material/Checkbox";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormHelperText from "@mui/material/FormHelperText";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormLabel from "@mui/material/FormLabel";
-import ListItem from "@mui/material/ListItem";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import TextField from "@mui/material/TextField";
+import Box from "@mui/material/Box";
 import { SxProps } from "@mui/system";
 import { Theme } from "@mui/material";
 
@@ -27,20 +29,20 @@ import {
   ExportFormat,
   ExportTimeRange,
 } from "@/states/controlState";
-import SettingsPanel from "./SettingsPanel";
-import SettingsSubPanel from "./SettingsSubPanel";
-
 const styles: Record<string, SxProps<Theme>> = {
-  separatorTextField: (theme) => ({
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    fontSize: theme.typography.fontSize / 2,
-    maxWidth: "5rem",
+  content: (theme) => ({ paddingTop: theme.spacing(1) }),
+  options: (theme) => ({ display: "grid", gap: theme.spacing(3) }),
+  optionGroup: (theme) => ({ display: "grid", gap: theme.spacing(0.5) }),
+  choices: (theme) => ({
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(12rem, 1fr))",
+    columnGap: theme.spacing(2),
   }),
-  fileNameTextField: (theme) => ({
-    marginLeft: theme.spacing(1),
-    marginRight: theme.spacing(1),
-    fontSize: theme.typography.fontSize / 2,
+  fileOptions: (theme) => ({
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(12rem, 1fr))",
+    gap: theme.spacing(2),
+    alignItems: "start",
   }),
 };
 
@@ -126,12 +128,19 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
         onClose={handleCloseDialog}
         scroll="body"
       >
-        <DialogContent>
-          <SettingsPanel title={i18n.get("Export Settings")}>
-            <ExportOptionGroup label={i18n.get("Data")}>
+        <DialogTitle>{i18n.get("Export data")}</DialogTitle>
+        <DialogContent sx={styles.content}>
+          <Box sx={styles.options}>
+            <ExportOptionGroup
+              label={i18n.get("What would you like to export?")}
+              helperText={i18n.get(
+                "Time-series exports include values, place IDs, coordinates, and geometry.",
+              )}
+            >
               <RadioGroup
                 value={settings.exportDataType}
                 onChange={handleDataTypeChange}
+                sx={styles.choices}
               >
                 <FormControlLabel
                   value="timeSeries"
@@ -145,26 +154,36 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
                 />
               </RadioGroup>
             </ExportOptionGroup>
-            <ExportOptionGroup label={i18n.get("Export format")}>
-              <RadioGroup value={exportFormat} onChange={handleFormatChange}>
-                <FormControlLabel
-                  value="text"
-                  label={i18n.get("Text/CSV")}
-                  control={<Radio />}
-                  disabled={!isTimeSeriesExport}
-                />
-                <FormControlLabel
-                  value="geojson"
-                  label={i18n.get("GeoJSON")}
-                  control={<Radio />}
-                />
-              </RadioGroup>
-            </ExportOptionGroup>
+            {isTimeSeriesExport ? (
+              <ExportOptionGroup label={i18n.get("File format")}>
+                <RadioGroup
+                  value={exportFormat}
+                  onChange={handleFormatChange}
+                  sx={styles.choices}
+                >
+                  <FormControlLabel
+                    value="text"
+                    label={i18n.get("Text/CSV")}
+                    control={<Radio />}
+                  />
+                  <FormControlLabel
+                    value="geojson"
+                    label={i18n.get("GeoJSON")}
+                    control={<Radio />}
+                  />
+                </RadioGroup>
+              </ExportOptionGroup>
+            ) : (
+              <FormHelperText>
+                {i18n.get("Place geometries are exported as GeoJSON.")}
+              </FormHelperText>
+            )}
             {isTimeSeriesExport && (
               <ExportOptionGroup label={i18n.get("Time range")}>
                 <RadioGroup
                   value={exportTimeRange}
                   onChange={handleTimeRangeChange}
+                  sx={styles.choices}
                 >
                   <FormControlLabel
                     value="full"
@@ -180,38 +199,39 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
                 </RadioGroup>
               </ExportOptionGroup>
             )}
-            {isTextExport && (
-              <SettingsSubPanel
-                label={i18n.get("Separator for time-series data")}
-              >
-                <TextField
-                  variant="standard"
-                  sx={styles.separatorTextField}
-                  value={settings.exportTimeSeriesSeparator}
-                  onChange={handleSeparatorChange}
-                  margin="normal"
-                  size={"small"}
-                />
-              </SettingsSubPanel>
-            )}
-            <SettingsSubPanel label={i18n.get("Compress as ZIP")}>
-              <Checkbox
-                checked={settings.exportAsZipArchive}
-                onChange={handleZipArchiveChange}
-                inputProps={{ "aria-label": i18n.get("Compress as ZIP") }}
-              />
-            </SettingsSubPanel>
-            <SettingsSubPanel label={i18n.get("File name")}>
+            <Box sx={styles.fileOptions}>
               <TextField
-                variant="standard"
-                sx={styles.fileNameTextField}
+                fullWidth
+                label={i18n.get("File name")}
                 value={settings.exportFileName}
                 onChange={handleFileNameChange}
-                margin="normal"
-                size={"small"}
+                size="small"
+                helperText={i18n.get(
+                  "Use letters, numbers, hyphens, or underscores.",
+                )}
               />
-            </SettingsSubPanel>
-          </SettingsPanel>
+              {isTextExport && (
+                <TextField
+                  fullWidth
+                  label={i18n.get("Text/CSV separator")}
+                  value={settings.exportTimeSeriesSeparator}
+                  onChange={handleSeparatorChange}
+                  size="small"
+                  helperText={i18n.get("Enter one character or TAB.")}
+                />
+              )}
+              <FormControlLabel
+                label={i18n.get("Compress as ZIP")}
+                control={
+                  <Checkbox
+                    checked={settings.exportAsZipArchive}
+                    onChange={handleZipArchiveChange}
+                    inputProps={{ "aria-label": i18n.get("Compress as ZIP") }}
+                  />
+                }
+              />
+            </Box>
+          </Box>
         </DialogContent>
 
         <DialogActions>
@@ -246,16 +266,20 @@ const canDownload = (settings: ControlState, isTextExport: boolean) => {
 
 interface ExportOptionGroupProps {
   label: string;
+  helperText?: string;
   children: React.ReactNode;
 }
 
-function ExportOptionGroup({ label, children }: ExportOptionGroupProps) {
+function ExportOptionGroup({
+  label,
+  helperText,
+  children,
+}: ExportOptionGroupProps) {
   return (
-    <ListItem>
-      <FormControl component="fieldset" fullWidth>
-        <FormLabel component="legend">{label}</FormLabel>
-        {children}
-      </FormControl>
-    </ListItem>
+    <FormControl component="fieldset" fullWidth sx={styles.optionGroup}>
+      <FormLabel component="legend">{label}</FormLabel>
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      {children}
+    </FormControl>
   );
 }

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -6,18 +6,29 @@
 
 import React, { ChangeEvent } from "react";
 import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormLabel from "@mui/material/FormLabel";
+import ListItem from "@mui/material/ListItem";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
 import TextField from "@mui/material/TextField";
 import { SxProps } from "@mui/system";
 import { Theme } from "@mui/material";
 
 import i18n from "@/i18n";
-import { ControlState } from "@/states/controlState";
+import {
+  ControlState,
+  ExportDataType,
+  ExportFormat,
+  ExportTimeRange,
+} from "@/states/controlState";
 import SettingsPanel from "./SettingsPanel";
 import SettingsSubPanel from "./SettingsSubPanel";
-import ToggleSetting from "./ToggleSetting";
 
 const styles: Record<string, SxProps<Theme>> = {
   separatorTextField: (theme) => ({
@@ -38,7 +49,7 @@ interface ExportDialogProps {
   closeDialog: (dialogId: string) => void;
   settings: ControlState;
   updateSettings: (settings: Partial<ControlState>) => void;
-  downloadTimeSeries: () => void;
+  downloadData: () => void;
 }
 
 const ExportDialog: React.FC<ExportDialogProps> = ({
@@ -46,7 +57,7 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
   closeDialog,
   settings,
   updateSettings,
-  downloadTimeSeries,
+  downloadData,
 }) => {
   const handleCloseDialog = () => {
     closeDialog("export");
@@ -64,10 +75,47 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
     updateSettings({ exportTimeSeriesSeparator: event.target.value });
   }
 
+  function handleDataTypeChange(
+    _event: React.ChangeEvent<HTMLInputElement>,
+    value: string,
+  ) {
+    const exportDataType = value as ExportDataType;
+    updateSettings({
+      exportDataType,
+      ...(exportDataType === "places" ? { exportFormat: "geojson" } : {}),
+    });
+  }
+
+  function handleFormatChange(
+    _event: React.ChangeEvent<HTMLInputElement>,
+    value: string,
+  ) {
+    updateSettings({ exportFormat: value as ExportFormat });
+  }
+
+  function handleTimeRangeChange(
+    _event: React.ChangeEvent<HTMLInputElement>,
+    value: string,
+  ) {
+    updateSettings({ exportTimeRange: value as ExportTimeRange });
+  }
+
+  function handleZipArchiveChange(event: React.ChangeEvent<HTMLInputElement>) {
+    updateSettings({ exportAsZipArchive: event.target.checked });
+  }
+
   const handleDoExport = () => {
     handleCloseDialog();
-    downloadTimeSeries();
+    downloadData();
   };
+
+  const isTimeSeriesExport = settings.exportDataType === "timeSeries";
+  const exportFormat = isTimeSeriesExport ? settings.exportFormat : "geojson";
+  const isTextExport = exportFormat === "text";
+  const hasDisplayedTimeRange = settings.selectedTimeRange !== null;
+  const exportTimeRange = hasDisplayedTimeRange
+    ? settings.exportTimeRange
+    : "full";
 
   return (
     <div>
@@ -80,58 +128,77 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
       >
         <DialogContent>
           <SettingsPanel title={i18n.get("Export Settings")}>
-            <SettingsSubPanel
-              label={i18n.get("Include time-series data") + " (*.txt)"}
-              value={getOnOff(settings.exportTimeSeries)}
-            >
-              <ToggleSetting
-                propertyName={"exportTimeSeries"}
-                settings={settings}
-                updateSettings={updateSettings}
-              />
-            </SettingsSubPanel>
-            <SettingsSubPanel
-              label={i18n.get("Separator for time-series data")}
-            >
-              <TextField
-                variant="standard"
-                sx={styles.separatorTextField}
-                value={settings.exportTimeSeriesSeparator}
-                onChange={handleSeparatorChange}
-                disabled={!settings.exportTimeSeries}
-                margin="normal"
-                size={"small"}
-              />
-            </SettingsSubPanel>
-            <SettingsSubPanel
-              label={i18n.get("Include places data") + " (*.geojson)"}
-              value={getOnOff(settings.exportPlaces)}
-            >
-              <ToggleSetting
-                propertyName={"exportPlaces"}
-                settings={settings}
-                updateSettings={updateSettings}
-              />
-            </SettingsSubPanel>
-            <SettingsSubPanel
-              label={i18n.get("Combine place data in one file")}
-              value={getOnOff(settings.exportPlacesAsCollection)}
-            >
-              <ToggleSetting
-                propertyName={"exportPlacesAsCollection"}
-                settings={settings}
-                updateSettings={updateSettings}
-                disabled={!settings.exportPlaces}
-              />
-            </SettingsSubPanel>
-            <SettingsSubPanel
-              label={i18n.get("As ZIP archive")}
-              value={getOnOff(settings.exportZipArchive)}
-            >
-              <ToggleSetting
-                propertyName={"exportZipArchive"}
-                settings={settings}
-                updateSettings={updateSettings}
+            <ExportOptionGroup label={i18n.get("Data")}>
+              <RadioGroup
+                value={settings.exportDataType}
+                onChange={handleDataTypeChange}
+              >
+                <FormControlLabel
+                  value="timeSeries"
+                  label={i18n.get("Time-series data with place information")}
+                  control={<Radio />}
+                />
+                <FormControlLabel
+                  value="places"
+                  label={i18n.get("Place geometries only")}
+                  control={<Radio />}
+                />
+              </RadioGroup>
+            </ExportOptionGroup>
+            <ExportOptionGroup label={i18n.get("Export format")}>
+              <RadioGroup value={exportFormat} onChange={handleFormatChange}>
+                <FormControlLabel
+                  value="text"
+                  label={i18n.get("Text/CSV")}
+                  control={<Radio />}
+                  disabled={!isTimeSeriesExport}
+                />
+                <FormControlLabel
+                  value="geojson"
+                  label={i18n.get("GeoJSON")}
+                  control={<Radio />}
+                />
+              </RadioGroup>
+            </ExportOptionGroup>
+            {isTimeSeriesExport && (
+              <ExportOptionGroup label={i18n.get("Time range")}>
+                <RadioGroup
+                  value={exportTimeRange}
+                  onChange={handleTimeRangeChange}
+                >
+                  <FormControlLabel
+                    value="full"
+                    label={i18n.get("Full time series")}
+                    control={<Radio />}
+                  />
+                  <FormControlLabel
+                    value="displayed"
+                    label={i18n.get("Displayed time range")}
+                    control={<Radio />}
+                    disabled={!hasDisplayedTimeRange}
+                  />
+                </RadioGroup>
+              </ExportOptionGroup>
+            )}
+            {isTextExport && (
+              <SettingsSubPanel
+                label={i18n.get("Separator for time-series data")}
+              >
+                <TextField
+                  variant="standard"
+                  sx={styles.separatorTextField}
+                  value={settings.exportTimeSeriesSeparator}
+                  onChange={handleSeparatorChange}
+                  margin="normal"
+                  size={"small"}
+                />
+              </SettingsSubPanel>
+            )}
+            <SettingsSubPanel label={i18n.get("Compress as ZIP")}>
+              <Checkbox
+                checked={settings.exportAsZipArchive}
+                onChange={handleZipArchiveChange}
+                inputProps={{ "aria-label": i18n.get("Compress as ZIP") }}
               />
             </SettingsSubPanel>
             <SettingsSubPanel label={i18n.get("File name")}>
@@ -148,7 +215,10 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
         </DialogContent>
 
         <DialogActions>
-          <Button onClick={handleDoExport} disabled={!canDownload(settings)}>
+          <Button
+            onClick={handleDoExport}
+            disabled={!canDownload(settings, isTextExport)}
+          >
             {i18n.get("Download")}
           </Button>
         </DialogActions>
@@ -159,10 +229,6 @@ const ExportDialog: React.FC<ExportDialogProps> = ({
 
 export default ExportDialog;
 
-const getOnOff = (state: boolean): string => {
-  return state ? i18n.get("On") : i18n.get("Off");
-};
-
 const isValidFileName = (fileName: string) => {
   return /^[0-9a-zA-Z_-]+$/.test(fileName);
 };
@@ -171,11 +237,25 @@ const isValidSeparator = (separator: string) => {
   return separator.toUpperCase() === "TAB" || separator.length === 1;
 };
 
-const canDownload = (settings: ControlState) => {
+const canDownload = (settings: ControlState, isTextExport: boolean) => {
   return (
-    (settings.exportTimeSeries || settings.exportPlaces) &&
     isValidFileName(settings.exportFileName) &&
-    (!settings.exportTimeSeries ||
-      isValidSeparator(settings.exportTimeSeriesSeparator))
+    (!isTextExport || isValidSeparator(settings.exportTimeSeriesSeparator))
   );
 };
+
+interface ExportOptionGroupProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function ExportOptionGroup({ label, children }: ExportOptionGroupProps) {
+  return (
+    <ListItem>
+      <FormControl component="fieldset" fullWidth>
+        <FormLabel component="legend">{label}</FormLabel>
+        {children}
+      </FormControl>
+    </ListItem>
+  );
+}

--- a/src/connected/ExportDialog.tsx
+++ b/src/connected/ExportDialog.tsx
@@ -22,7 +22,7 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = {
   closeDialog,
   updateSettings,
-  downloadTimeSeries: exportData,
+  downloadData: exportData,
 };
 
 const ExportDialog = connect(

--- a/src/model/dataExport.ts
+++ b/src/model/dataExport.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import * as geojson from "geojson";
+import JSZip from "jszip";
+
+import { PlaceGroup } from "./place";
+import {
+  TimeRange,
+  TimeSeriesGroup,
+  timeSeriesGroupsToGeoJSON,
+  timeSeriesGroupsToTable,
+  timeSeriesTableToDelimitedText,
+} from "./timeSeries";
+
+export type ExportDataType = "timeSeries" | "places";
+export type ExportFormat = "text" | "geojson";
+export type ExportTimeRange = "full" | "displayed";
+
+export const EXPORT_DATA_TYPES: ExportDataType[] = ["timeSeries", "places"];
+export const EXPORT_FORMATS: ExportFormat[] = ["text", "geojson"];
+export const EXPORT_TIME_RANGES: ExportTimeRange[] = ["full", "displayed"];
+
+export interface ExportOptions {
+  dataType: ExportDataType;
+  format: ExportFormat;
+  timeRange: TimeRange | null;
+  separator: string;
+  fileName: string;
+}
+
+export interface ExportFile {
+  fileName: string;
+  content: string;
+  contentType: string;
+}
+
+export function createExportArchive(exportFile: ExportFile): Promise<Blob> {
+  const archive = new JSZip();
+  archive.file(exportFile.fileName, exportFile.content);
+  return archive.generateAsync({ type: "blob", compression: "DEFLATE" });
+}
+
+export function createExportFile(
+  timeSeriesGroups: TimeSeriesGroup[],
+  placeGroups: PlaceGroup[],
+  options: ExportOptions,
+): ExportFile {
+  const { dataType, format, timeRange, separator, fileName } = options;
+  const rootFileName = fileName || "export";
+  if (dataType === "places") {
+    return createGeoJSONExportFile(
+      rootFileName,
+      getPlacesCollection(placeGroups),
+    );
+  }
+  if (format === "geojson") {
+    return createGeoJSONExportFile(
+      rootFileName,
+      timeSeriesGroupsToGeoJSON(timeSeriesGroups, timeRange),
+    );
+  }
+  const table = timeSeriesGroupsToTable(
+    timeSeriesGroups,
+    placeGroups,
+    timeRange,
+  );
+  return {
+    fileName: `${rootFileName}.txt`,
+    content: timeSeriesTableToDelimitedText(table, getSeparator(separator)),
+    contentType: "text/plain;charset=utf-8",
+  };
+}
+
+function getSeparator(separator: string): string {
+  return separator.toUpperCase() === "TAB" ? "\t" : separator;
+}
+
+function getPlacesCollection(
+  placeGroups: PlaceGroup[],
+): geojson.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: placeGroups.flatMap((placeGroup) => placeGroup.features || []),
+  };
+}
+
+function createGeoJSONExportFile(
+  fileName: string,
+  content: object,
+): ExportFile {
+  return {
+    fileName: `${fileName}.geojson`,
+    content: JSON.stringify(content, null, 2),
+    contentType: "application/geo+json;charset=utf-8",
+  };
+}

--- a/src/model/timeSeries.test.ts
+++ b/src/model/timeSeries.test.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as geojson from "geojson";
+
+import { Place, PlaceGroup } from "./place";
+import {
+  TimeSeries,
+  TimeSeriesGroup,
+  timeSeriesGroupsToGeoJSON,
+  timeSeriesGroupsToTable,
+  timeSeriesTableToDelimitedText,
+} from "./timeSeries";
+
+const firstTime = Date.parse("2024-01-01T00:00:00Z");
+const secondTime = Date.parse("2024-01-02T00:00:00Z");
+
+const sourcePointGeometry: geojson.Point = {
+  type: "Point",
+  coordinates: [12.5, 48.1],
+};
+
+const pointPlace: Place = {
+  id: "point-1",
+  type: "Feature",
+  // The source geometry must take precedence over a later changed place.
+  geometry: { type: "Point", coordinates: [0, 0] },
+  properties: {},
+};
+
+const polygonPlace: Place = {
+  id: "polygon-1",
+  type: "Feature",
+  geometry: {
+    type: "Polygon",
+    coordinates: [
+      [
+        [10, 40],
+        [11, 40],
+        [11, 41],
+        [10, 40],
+      ],
+    ],
+  },
+  properties: {},
+};
+
+const placeGroups: PlaceGroup[] = [
+  {
+    id: "places",
+    title: "Places",
+    type: "FeatureCollection",
+    features: [pointPlace, polygonPlace],
+  },
+];
+
+const temperatureSeries: TimeSeries = {
+  source: {
+    datasetId: "dataset",
+    datasetTitle: "Dataset",
+    variableName: "temperature",
+    variableUnits: "K",
+    placeId: "point-1",
+    geometry: sourcePointGeometry,
+    valueDataKey: "mean",
+    errorDataKey: "std",
+  },
+  data: [
+    { time: firstTime, countTot: 1, mean: 280, std: 0.2 },
+    { time: secondTime, countTot: 1, mean: 281, std: 0.3 },
+  ],
+};
+
+const precipitationSeries: TimeSeries = {
+  source: {
+    datasetId: "dataset",
+    datasetTitle: "Dataset",
+    variableName: "precipitation",
+    variableUnits: "mm",
+    placeId: "point-1",
+    geometry: sourcePointGeometry,
+    valueDataKey: "mean",
+    errorDataKey: null,
+  },
+  data: [
+    { time: firstTime, countTot: 1, mean: 3 },
+    { time: secondTime, countTot: 1, mean: 4 },
+  ],
+};
+
+const polygonSeries: TimeSeries = {
+  source: {
+    datasetId: "dataset",
+    datasetTitle: "Dataset",
+    variableName: "temperature",
+    variableUnits: "K",
+    placeId: "polygon-1",
+    geometry: polygonPlace.geometry,
+    valueDataKey: "mean",
+    errorDataKey: null,
+  },
+  data: [{ time: firstTime, countTot: 1, mean: 279 }],
+};
+
+const timeSeriesGroups: TimeSeriesGroup[] = [
+  {
+    id: "group",
+    timeSeriesArray: [temperatureSeries, precipitationSeries, polygonSeries],
+  },
+];
+
+describe("time-series export tables", () => {
+  it("includes place IDs, coordinates, geometries, and merged values", () => {
+    const table = timeSeriesGroupsToTable(timeSeriesGroups, placeGroups);
+
+    expect(table.colNames).toEqual([
+      "placeId",
+      "longitude",
+      "latitude",
+      "geometry",
+      "time",
+      "dataset.precipitation.mean",
+      "dataset.temperature.mean",
+      "dataset.temperature.std",
+    ]);
+    expect(table.dataRows).toEqual([
+      [
+        "point-1",
+        12.5,
+        48.1,
+        JSON.stringify(sourcePointGeometry),
+        "2024-01-01 00:00:00",
+        3,
+        280,
+        0.2,
+      ],
+      [
+        "polygon-1",
+        null,
+        null,
+        JSON.stringify(polygonPlace.geometry),
+        "2024-01-01 00:00:00",
+        undefined,
+        279,
+        undefined,
+      ],
+      [
+        "point-1",
+        12.5,
+        48.1,
+        JSON.stringify(sourcePointGeometry),
+        "2024-01-02 00:00:00",
+        4,
+        281,
+        0.3,
+      ],
+    ]);
+  });
+
+  it("keeps missing place references and imported series exportable", () => {
+    const importedSeries: TimeSeries = {
+      source: {
+        datasetId: "imported",
+        datasetTitle: "Imported",
+        variableName: "value",
+        placeId: null,
+        geometry: null,
+        valueDataKey: "mean",
+        errorDataKey: null,
+      },
+      data: [{ time: firstTime, countTot: 1, mean: 2 }],
+    };
+    const missingPlaceSeries: TimeSeries = {
+      ...temperatureSeries,
+      source: { ...temperatureSeries.source, placeId: "missing-place" },
+      data: [{ time: firstTime, countTot: 1, mean: 282 }],
+    };
+
+    const table = timeSeriesGroupsToTable(
+      [{ id: "group", timeSeriesArray: [importedSeries, missingPlaceSeries] }],
+      [],
+    );
+
+    expect(table.dataRows).toEqual([
+      [null, null, null, null, "2024-01-01 00:00:00", undefined, undefined, 2],
+      [
+        "missing-place",
+        12.5,
+        48.1,
+        JSON.stringify(sourcePointGeometry),
+        "2024-01-01 00:00:00",
+        282,
+        undefined,
+        undefined,
+      ],
+    ]);
+    expect(table.referencedPlaces).toEqual({});
+  });
+
+  it("filters the displayed range inclusively and safely formats delimited text", () => {
+    const table = timeSeriesGroupsToTable(timeSeriesGroups, placeGroups, [
+      secondTime,
+      secondTime,
+    ]);
+
+    expect(table.dataRows).toHaveLength(1);
+    expect(table.dataRows[0][4]).toBe("2024-01-02 00:00:00");
+
+    const commaSeparated = timeSeriesTableToDelimitedText(table, ",");
+    expect(commaSeparated).toContain(
+      '"{""type"":""Point"",""coordinates"":[12.5,48.1]}"',
+    );
+  });
+});
+
+describe("time-series GeoJSON export", () => {
+  it("preserves geometry, place ID, values, and the selected time range", () => {
+    const collection = timeSeriesGroupsToGeoJSON(
+      [
+        {
+          id: "group",
+          timeSeriesArray: [temperatureSeries, polygonSeries],
+        },
+      ],
+      [secondTime, secondTime],
+    );
+
+    expect(collection).toEqual({
+      type: "FeatureCollection",
+      features: [
+        {
+          id: "dataset-temperature-point-1",
+          type: "Feature",
+          geometry: sourcePointGeometry,
+          properties: {
+            datasetId: "dataset",
+            datasetTitle: "Dataset",
+            variableName: "temperature",
+            variableUnits: "K",
+            placeId: "point-1",
+            valueDataKey: "mean",
+            errorDataKey: "std",
+            data: [
+              {
+                time: "2024-01-02 00:00:00",
+                countTot: 1,
+                mean: 281,
+                std: 0.3,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/model/timeSeries.ts
+++ b/src/model/timeSeries.ts
@@ -74,6 +74,9 @@ type CellValue = number | string | null | undefined;
 type DataRow = CellValue[];
 type RowData = {
   placeId: string | null;
+  longitude: number | null;
+  latitude: number | null;
+  geometry: string | null;
   time: string;
   [colName: string]: CellValue;
 };
@@ -85,9 +88,23 @@ export interface TimeSeriesTable {
   referencedPlaces: { [placeId: string]: Place };
 }
 
+export function timeSeriesTableToDelimitedText(
+  table: TimeSeriesTable,
+  separator: string,
+): string {
+  return [table.colNames, ...table.dataRows]
+    .map((row) =>
+      row
+        .map((value) => formatDelimitedValue(value, separator))
+        .join(separator),
+    )
+    .join("\n");
+}
+
 export function timeSeriesGroupsToTable(
   timeSeriesGroups: TimeSeriesGroup[],
   placeGroups: PlaceGroup[],
+  timeRange: TimeRange | null = null,
 ): TimeSeriesTable {
   const dataColNames = new Set<string>();
   const placeIds = new Set<string>();
@@ -96,9 +113,6 @@ export function timeSeriesGroupsToTable(
     for (const timeSeries of timeSeriesGroup.timeSeriesArray) {
       const { placeId, datasetId, variableName, valueDataKey, errorDataKey } =
         timeSeries.source;
-      if (placeId !== null) {
-        placeIds.add(placeId);
-      }
       const valueColName = `${datasetId}.${variableName}.${valueDataKey}`;
       dataColNames.add(valueColName);
       let errorColName: string | null = null;
@@ -106,7 +120,17 @@ export function timeSeriesGroupsToTable(
         errorColName = `${datasetId}.${variableName}.${errorDataKey}`;
         dataColNames.add(errorColName);
       }
-      timeSeries.data.forEach((point) => {
+
+      const place = findPlaceInPlaceGroups(placeGroups, placeId);
+      const spatialData = getSpatialData(
+        timeSeries.source.geometry ?? place?.geometry ?? null,
+      );
+
+      const data = filterTimeSeriesData(timeSeries.data, timeRange);
+      if (placeId !== null && data.length > 0) {
+        placeIds.add(placeId);
+      }
+      data.forEach((point) => {
         const time = utcTimeToIsoDateTimeString(point.time);
         // if placeId is null, then data is from import CSV / GeoJSON
         // and datasetId is the name of the place group.
@@ -115,6 +139,7 @@ export function timeSeriesGroupsToTable(
         if (!timePlaceRow) {
           timePlaceRows[timePlaceId] = {
             placeId,
+            ...spatialData,
             time,
             [valueColName]: point[valueDataKey],
           };
@@ -131,9 +156,13 @@ export function timeSeriesGroupsToTable(
     }
   }
 
-  const colNames: string[] = ["placeId", "time"].concat(
-    Array.from(dataColNames).sort(),
-  );
+  const colNames: string[] = [
+    "placeId",
+    "longitude",
+    "latitude",
+    "geometry",
+    "time",
+  ].concat(Array.from(dataColNames).sort());
   const dataRows: DataRow[] = [];
 
   Object.keys(timePlaceRows).forEach((timePlaceId) => {
@@ -146,20 +175,23 @@ export function timeSeriesGroupsToTable(
   });
 
   dataRows.sort((row1, row2) => {
-    const time1: string = row1[1] as string;
-    const time2: string = row2[1] as string;
+    const time1 = String(row1[4] ?? "");
+    const time2 = String(row2[4] ?? "");
     const timeDelta = time1.localeCompare(time2);
     if (timeDelta !== 0) {
       return timeDelta;
     }
-    const placeId1: string = row1[0] as string;
-    const placeId2: string = row2[0] as string;
+    const placeId1 = String(row1[0] ?? "");
+    const placeId2 = String(row2[0] ?? "");
     return placeId1.localeCompare(placeId2);
   });
 
   const referencedPlaces: { [placeId: string]: Place } = {};
   placeIds.forEach((placeId) => {
-    referencedPlaces[placeId] = findPlaceInPlaceGroups(placeGroups, placeId)!;
+    const place = findPlaceInPlaceGroups(placeGroups, placeId);
+    if (place !== null) {
+      referencedPlaces[placeId] = place;
+    }
   });
 
   return { colNames, dataRows, referencedPlaces };
@@ -167,14 +199,63 @@ export function timeSeriesGroupsToTable(
 
 export function timeSeriesGroupsToGeoJSON(
   timeSeriesGroups: TimeSeriesGroup[],
+  timeRange: TimeRange | null = null,
 ): geojson.FeatureCollection<geojson.Geometry | null> {
   const features: geojson.Feature<geojson.Geometry | null>[] = [];
   for (const timeSeriesGroup of timeSeriesGroups) {
     for (const timeSeries of timeSeriesGroup.timeSeriesArray) {
-      features.push(timeSeriesToGeoJSON(timeSeries));
+      const data = filterTimeSeriesData(timeSeries.data, timeRange);
+      if (data.length > 0) {
+        features.push(timeSeriesToGeoJSON({ ...timeSeries, data }));
+      }
     }
   }
   return { type: "FeatureCollection", features };
+}
+
+function filterTimeSeriesData(
+  data: TimeSeriesPoint[],
+  timeRange: TimeRange | null,
+): TimeSeriesPoint[] {
+  if (timeRange === null) {
+    return data;
+  }
+  const [startTime, endTime] = timeRange;
+  return data.filter(
+    (point) => point.time >= startTime && point.time <= endTime,
+  );
+}
+
+function getSpatialData(geometry: geojson.Geometry | null): {
+  longitude: number | null;
+  latitude: number | null;
+  geometry: string | null;
+} {
+  let longitude: number | null = null;
+  let latitude: number | null = null;
+  if (geometry?.type === "Point") {
+    const [x, y] = geometry.coordinates;
+    if (typeof x === "number" && typeof y === "number") {
+      longitude = x;
+      latitude = y;
+    }
+  }
+  return {
+    longitude,
+    latitude,
+    geometry: geometry === null ? null : JSON.stringify(geometry),
+  };
+}
+
+function formatDelimitedValue(value: CellValue, separator: string): string {
+  if (value === null || typeof value === "undefined") {
+    return "";
+  }
+  const text = String(value);
+  const escapedText = text.replace(/"/g, '""');
+  return escapedText.includes(separator) || /[\r\n"]/.test(text)
+    ? `"${escapedText}"`
+    : escapedText;
 }
 
 export function timeSeriesToGeoJSON(

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -546,6 +546,46 @@
       "se": "Exportera Inställningar"
     },
     {
+      "en": "Data",
+      "de": "Daten",
+      "se": "Data"
+    },
+    {
+      "en": "Export format",
+      "de": "Exportformat",
+      "se": "Exportformat"
+    },
+    {
+      "en": "Time-series data with place information",
+      "de": "Zeitreihendaten mit Ortsinformationen",
+      "se": "Tidsseriedata med platsinformation"
+    },
+    {
+      "en": "Place geometries only",
+      "de": "Nur Ortsgeometrien",
+      "se": "Endast platsgeometrier"
+    },
+    {
+      "en": "Time range",
+      "de": "Zeitbereich",
+      "se": "Tidsintervall"
+    },
+    {
+      "en": "Full time series",
+      "de": "Vollständige Zeitreihe",
+      "se": "Hela tidsserien"
+    },
+    {
+      "en": "Displayed time range",
+      "de": "Angezeigter Zeitbereich",
+      "se": "Visat tidsintervall"
+    },
+    {
+      "en": "Compress as ZIP",
+      "de": "Als ZIP komprimieren",
+      "se": "Komprimera som ZIP"
+    },
+    {
       "en": "Include time-series data",
       "de": "Zeitseriendaten einschließen",
       "se": "Inkludera tidsseriedata"

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -22,6 +22,20 @@ import { defaultWktOptions, WktOptions } from "@/model/user-place/wkt";
 import { loadUserSettings } from "./userSettings";
 import { PaletteMode } from "@mui/material";
 import { LayerState } from "@/model/layerState";
+import type {
+  ExportDataType,
+  ExportFormat,
+  ExportTimeRange,
+} from "@/model/dataExport";
+
+export {
+  EXPORT_DATA_TYPES,
+  EXPORT_FORMATS,
+  EXPORT_TIME_RANGES,
+  type ExportDataType,
+  type ExportFormat,
+  type ExportTimeRange,
+} from "@/model/dataExport";
 
 export type TimeAnimationInterval = 250 | 500 | 1000 | 2500;
 export const TIME_ANIMATION_INTERVALS: TimeAnimationInterval[] = [
@@ -29,11 +43,7 @@ export const TIME_ANIMATION_INTERVALS: TimeAnimationInterval[] = [
 ];
 
 export type MapInteraction =
-  | "Select"
-  | "Point"
-  | "Polygon"
-  | "Circle"
-  | "Geometry";
+  "Select" | "Point" | "Polygon" | "Circle" | "Geometry";
 
 export type ViewMode = "text" | "list" | "code" | "python";
 
@@ -128,11 +138,11 @@ export interface ControlState {
   userColorBars: UserColorBar[];
   datasetLocateMode: LocateMode;
   placeLocateMode: LocateMode;
-  exportTimeSeries: boolean;
-  exportPlaces: boolean;
+  exportDataType: ExportDataType;
+  exportFormat: ExportFormat;
+  exportTimeRange: ExportTimeRange;
+  exportAsZipArchive: boolean;
   exportTimeSeriesSeparator: string;
-  exportPlacesAsCollection: boolean;
-  exportZipArchive: boolean;
   exportFileName: string;
   themeMode: ThemeMode;
   exportResolution: ExportResolution;
@@ -213,11 +223,11 @@ export function newControlState(): ControlState {
     userBaseMaps: [],
     userOverlays: [],
     userColorBars: [],
-    exportTimeSeries: true,
+    exportDataType: "timeSeries",
+    exportFormat: "text",
+    exportTimeRange: "full",
+    exportAsZipArchive: false,
     exportTimeSeriesSeparator: "TAB",
-    exportPlaces: true,
-    exportPlacesAsCollection: true,
-    exportZipArchive: true,
     exportFileName: "export",
     themeMode: getInitialThemeMode(),
     exportResolution: 300,

--- a/src/states/userSettings.test.ts
+++ b/src/states/userSettings.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019-2026 by xcube team and contributors
+ * Permissions are hereby granted under the terms of the MIT License:
+ * https://opensource.org/licenses/MIT.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Config } from "@/config";
+import { ControlState } from "./controlState";
+import { loadUserSettings, storeUserSettings } from "./userSettings";
+
+const defaultSettings = {
+  exportDataType: "timeSeries",
+  exportFormat: "text",
+  exportTimeRange: "full",
+  exportAsZipArchive: false,
+  exportTimeSeriesSeparator: "TAB",
+  exportFileName: "export",
+} as ControlState;
+
+describe("export user settings", () => {
+  beforeEach(() => {
+    vi.spyOn(Config, "instance", "get").mockReturnValue({
+      name: "test",
+    } as Config);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("stores and restores the selected export options", () => {
+    const settings = {
+      ...defaultSettings,
+      exportDataType: "places",
+      exportFormat: "geojson",
+      exportTimeRange: "displayed",
+      exportAsZipArchive: true,
+    } as ControlState;
+
+    storeUserSettings(settings);
+
+    expect(loadUserSettings(defaultSettings)).toMatchObject({
+      exportDataType: "places",
+      exportFormat: "geojson",
+      exportTimeRange: "displayed",
+      exportAsZipArchive: true,
+    });
+  });
+
+  it("falls back to valid defaults for malformed stored export settings", () => {
+    window.localStorage.setItem("xcube.test.exportDataType", "invalid");
+    window.localStorage.setItem("xcube.test.exportFormat", "invalid");
+    window.localStorage.setItem("xcube.test.exportTimeRange", "invalid");
+
+    expect(loadUserSettings(defaultSettings)).toMatchObject({
+      exportDataType: "timeSeries",
+      exportFormat: "text",
+      exportTimeRange: "full",
+    });
+  });
+
+  it("does not reuse the legacy ZIP setting", () => {
+    window.localStorage.setItem("xcube.test.exportZipArchive", "true");
+
+    expect(loadUserSettings(defaultSettings)).toMatchObject({
+      exportAsZipArchive: false,
+    });
+  });
+});

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -7,7 +7,12 @@
 import { Config } from "@/config";
 import { ApiServerConfig } from "@/model/apiServer";
 import { getLocalStorage } from "@/util/storage";
-import { ControlState } from "./controlState";
+import {
+  ControlState,
+  EXPORT_DATA_TYPES,
+  EXPORT_FORMATS,
+  EXPORT_TIME_RANGES,
+} from "./controlState";
 import { UserVariable } from "@/model/userVariable";
 import { ColorMapType } from "@/model/colorBar";
 import { isString } from "@/util/types";
@@ -86,11 +91,11 @@ export function storeUserSettings(settings: ControlState) {
       storage.setPrimitiveProperty("userDrawnPlaceGroupName", settings);
       storage.setPrimitiveProperty("datasetLocateMode", settings);
       storage.setPrimitiveProperty("placeLocateMode", settings);
-      storage.setPrimitiveProperty("exportTimeSeries", settings);
+      storage.setPrimitiveProperty("exportDataType", settings);
+      storage.setPrimitiveProperty("exportFormat", settings);
+      storage.setPrimitiveProperty("exportTimeRange", settings);
+      storage.setPrimitiveProperty("exportAsZipArchive", settings);
       storage.setPrimitiveProperty("exportTimeSeriesSeparator", settings);
-      storage.setPrimitiveProperty("exportPlaces", settings);
-      storage.setPrimitiveProperty("exportPlacesAsCollection", settings);
-      storage.setPrimitiveProperty("exportZipArchive", settings);
       storage.setPrimitiveProperty("exportFileName", settings);
       storage.setPrimitiveProperty("userPlacesFormatName", settings);
       storage.setObjectProperty("userPlacesFormatOptions", settings);
@@ -175,19 +180,19 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
       );
       storage.getStringProperty("datasetLocateMode", settings, defaultSettings);
       storage.getStringProperty("placeLocateMode", settings, defaultSettings);
-      storage.getBooleanProperty("exportTimeSeries", settings, defaultSettings);
+      storage.getStringProperty("exportDataType", settings, defaultSettings);
+      storage.getStringProperty("exportFormat", settings, defaultSettings);
+      storage.getStringProperty("exportTimeRange", settings, defaultSettings);
+      storage.getBooleanProperty(
+        "exportAsZipArchive",
+        settings,
+        defaultSettings,
+      );
       storage.getStringProperty(
         "exportTimeSeriesSeparator",
         settings,
         defaultSettings,
       );
-      storage.getBooleanProperty("exportPlaces", settings, defaultSettings);
-      storage.getBooleanProperty(
-        "exportPlacesAsCollection",
-        settings,
-        defaultSettings,
-      );
-      storage.getBooleanProperty("exportZipArchive", settings, defaultSettings);
       storage.getStringProperty("exportFileName", settings, defaultSettings);
       storage.getStringProperty(
         "userPlacesFormatName",
@@ -201,6 +206,15 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
       );
       storage.getStringProperty("themeMode", settings, defaultSettings);
       storage.getStringProperty("exportResolution", settings, defaultSettings);
+      if (!EXPORT_DATA_TYPES.includes(settings.exportDataType)) {
+        settings.exportDataType = defaultSettings.exportDataType;
+      }
+      if (!EXPORT_FORMATS.includes(settings.exportFormat)) {
+        settings.exportFormat = defaultSettings.exportFormat;
+      }
+      if (!EXPORT_TIME_RANGES.includes(settings.exportTimeRange)) {
+        settings.exportTimeRange = defaultSettings.exportTimeRange;
+      }
       if (import.meta.env.DEV) {
         console.debug("Loaded user settings:", settings);
       }


### PR DESCRIPTION
## Description

Closes #300.

Improves the export dialog and export output:

- Improves UI/UX by not only using switches.
- Exports time-series values, `placeId`, coordinates, and GeoJSON geometry together in one Text/CSV or GeoJSON file.
- Supports exporting the full time series or only the currently displayed range.
- Keeps place-only GeoJSON export.
- Keeps ZIP compression as optional. A ZIP contains exactly the selected single export file.

## Checklist

- [x] Add unit tests and/or doctests in docstrings
- [x] Add docstrings and API docs for any new/modified user-facing classes and functions
- [x] New/modified features documented in `docs/source/*`
- [x] Changes documented in `CHANGES.md`
- [x] GitHub CI passes
- [ ] Test coverage remains or increases (target 100%)