### PR TITLE
Fixed a problem when computing the extent of layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Fixes
 
+* Fixed a problem when computing the extent of variable and RGB layers.
+  We are now correctly using the extrema of the dataset's boundary polygon 
+  in coordinates of the viewer's map projection for the extent, rather than
+  using the dataset's geographical bounding box. (#593, #641)
+
 * Fixed the color bar update for a pinned variable. (#637)
 
 ### Other changes

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -7,6 +7,7 @@
 import OlTileLayer from "ol/layer/Tile";
 import { default as OlMap } from "ol/Map";
 import { default as OlView } from "ol/View";
+import { type GeoJSONPolygon } from "ol/format/GeoJSON";
 
 import { findDatasetMapLayer } from "@/components/ol/util";
 import { GEOGRAPHIC_CRS, WEB_MERCATOR_CRS } from "@/model/proj";
@@ -17,7 +18,6 @@ import { isString } from "@/util/types";
 import { type PlaceGroup } from "./place";
 import { type TimeRange } from "./timeSeries";
 import { type Variable } from "./variable";
-import { GeoJSONPolygon } from "ol/format/GeoJSON";
 
 export interface Dimension {
   name: string;

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -17,6 +17,7 @@ import { isString } from "@/util/types";
 import { type PlaceGroup } from "./place";
 import { type TimeRange } from "./timeSeries";
 import { type Variable } from "./variable";
+import { GeoJSONPolygon } from "ol/format/GeoJSON";
 
 export interface Dimension {
   name: string;
@@ -39,6 +40,7 @@ export interface TimeDimension extends Dimension {
 }
 
 export type NormRange = [number, number];
+export type BBox = [number, number, number, number];
 
 export interface RgbSchema {
   // The following are new since xcube 0.11
@@ -58,11 +60,8 @@ export interface Dataset {
   groupDescription?: string;
   sortValue?: number;
   tags?: string[];
-  bbox: [number, number, number, number];
-  geometry: {
-    type: "Polygon";
-    coordinates: Array<Array<[number, number]>>;
-  };
+  bbox: BBox;
+  geometry: GeoJSONPolygon;
   spatialRef: string;
   dimensions: Dimension[];
   variables: Variable[];

--- a/src/selectors/controlSelectors.test.tsx
+++ b/src/selectors/controlSelectors.test.tsx
@@ -6,8 +6,62 @@
 
 import { describe, expect, it } from "vitest";
 import { Dataset } from "@/model/dataset";
+import { GEOGRAPHIC_CRS, WEB_MERCATOR_CRS } from "@/model/proj";
 import { Variable } from "@/model/variable";
-import { getTileUrl } from "./controlSelectors";
+import { computeDatasetExtent, getTileUrl } from "./controlSelectors";
+
+describe("Assert that controlSelectors.computeDatasetExtent()", () => {
+  const datasetWithGeometry = (geometry: Dataset["geometry"]): Dataset =>
+    ({ geometry }) as Dataset;
+
+  const datasetBoundary = {
+    type: "Polygon",
+    coordinates: [
+      [
+        [10, 50],
+        [11, 50],
+        [12, 50],
+        [12, 51],
+        [12, 52],
+        [11, 52],
+        [10, 52],
+        [10, 51],
+        [10, 50],
+      ],
+    ],
+  } as Dataset["geometry"];
+
+  it("returns null when the dataset is missing", () => {
+    expect(computeDatasetExtent(null, WEB_MERCATOR_CRS)).toBeNull();
+  });
+
+  it("returns null when the dataset has no geometry", () => {
+    expect(computeDatasetExtent({} as Dataset, WEB_MERCATOR_CRS)).toBeNull();
+  });
+
+  it("returns the geographic extent without transforming it", () => {
+    expect(
+      computeDatasetExtent(
+        datasetWithGeometry(datasetBoundary),
+        GEOGRAPHIC_CRS,
+      ),
+    ).toEqual([10, 50, 12, 52]);
+  });
+
+  it("transforms the extent to Web Mercator", () => {
+    const extent = computeDatasetExtent(
+      datasetWithGeometry(datasetBoundary),
+      WEB_MERCATOR_CRS,
+    );
+
+    expect(extent).not.toBeNull();
+    expect(extent!.length).toBe(4);
+    expect(extent![0]).toBeCloseTo(1113194.91, 1);
+    expect(extent![1]).toBeCloseTo(6446275.84, 1);
+    expect(extent![2]).toBeCloseTo(1335833.89, 1);
+    expect(extent![3]).toBeCloseTo(6800125.45, 1);
+  });
+});
 
 describe("Assert that controlSelectors.getTileUrl()", () => {
   it("works for RGB", () => {

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -7,6 +7,7 @@
 import { JSX } from "react";
 import { createSelector } from "reselect";
 import memoize from "fast-memoize";
+import { Geometry } from "geojson";
 import {
   Feature as OlFeature,
   ImageTile as OlImageTile,
@@ -31,7 +32,6 @@ import { Layers } from "@/components/ol/layer/Layers";
 import { Tile } from "@/components/ol/layer/Tile";
 import { Vector } from "@/components/ol/layer/Vector";
 import { MapElement } from "@/components/ol/Map";
-
 import {
   BBox,
   Dataset,
@@ -55,7 +55,6 @@ import {
 } from "@/model/place";
 import { Time, TimeRange, TimeSeriesGroup } from "@/model/timeSeries";
 import { ColorBarNorm, Variable } from "@/model/variable";
-
 import { AppState } from "@/states/appState";
 import { findIndexCloseTo } from "@/util/find";
 import {
@@ -95,7 +94,6 @@ import {
 import { UserVariable } from "@/model/userVariable";
 import { encodeDatasetId, encodeVariableName } from "@/model/encode";
 import { StatisticsRecord } from "@/model/statistics";
-import { Geometry } from "geojson";
 import { LayerState } from "@/model/layerState";
 
 export const selectedDatasetIdSelector = (state: AppState) =>

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -7,9 +7,14 @@
 import { JSX } from "react";
 import { createSelector } from "reselect";
 import memoize from "fast-memoize";
-import { ImageTile as OlImageTile, Tile as OlTile } from "ol";
+import {
+  Feature as OlFeature,
+  ImageTile as OlImageTile,
+  Tile as OlTile,
+} from "ol";
 import { default as OlMap } from "ol/Map";
 import { default as OlGeoJSONFormat } from "ol/format/GeoJSON";
+import { default as OlGeometry } from "ol/geom/Geometry";
 import { default as OlVectorSource } from "ol/source/Vector";
 import { default as OlXYZSource } from "ol/source/XYZ";
 import { default as OlTileWMSSource } from "ol/source/TileWMS";
@@ -19,7 +24,6 @@ import { default as OlStrokeStyle } from "ol/style/Stroke";
 import { default as OlStyle } from "ol/style/Style";
 import { default as OlTileGrid } from "ol/tilegrid/TileGrid";
 import { LoadFunction } from "ol/Tile";
-import { transformExtent as olTransformExtent } from "ol/proj";
 
 import { Config, getUserPlaceFillOpacity } from "@/config";
 import { ApiServerConfig } from "@/model/apiServer";
@@ -29,6 +33,7 @@ import { Vector } from "@/components/ol/layer/Vector";
 import { MapElement } from "@/components/ol/Map";
 
 import {
+  BBox,
   Dataset,
   findDataset,
   findDatasetVariable,
@@ -178,6 +183,18 @@ export const selectedDataset2Selector = createSelector(
   datasetsSelector,
   selectedDataset2IdSelector,
   findDataset,
+);
+
+export const selectedDatasetExtentSelector = createSelector(
+  selectedDatasetSelector,
+  mapProjectionSelector,
+  computeDatasetExtent,
+);
+
+export const selectedDataset2ExtentSelector = createSelector(
+  selectedDataset2Selector,
+  mapProjectionSelector,
+  computeDatasetExtent,
 );
 
 export const getDatasetTitle = (dataset: Dataset | null) =>
@@ -918,7 +935,7 @@ function getLoadTileOnlyAfterMove() {
 function getTileLayer(
   layerId: string,
   tileUrl: string,
-  extent: [number, number, number, number],
+  extent: BBox | null,
   tileLevelMin: number | undefined,
   tileLevelMax: number | undefined,
   queryParams: Array<[string, string]>,
@@ -926,7 +943,6 @@ function getTileLayer(
   timeLabel: string | null,
   timeAnimationActive: boolean,
   mapProjection: string,
-  datasetProjection: string,
   attributions: string[] | null,
   imageSmoothing: boolean,
   zIndex: number = 10,
@@ -953,40 +969,37 @@ function getTileLayer(
     tileLevelMax,
   );
 
-  let transformedExtent;
-
-  if (
-    datasetProjection === GEOGRAPHIC_CRS ||
-    datasetProjection === WEB_MERCATOR_CRS
-  ) {
-    // Only use extent for EPSG:4326 and EPSG:3857.
-    // For other CRS (e.g. UTM, LAEA), transforming the bbox can be inaccurate
-    // and may clip valid tiles due to projection distortion.
-    // Disabling extent avoids rendering artifacts. It can trigger extra
-    // tile requests, but the performance impact should be small
-    // as xcube Server already handles out-of-bounds tiles.
-    if (mapProjection === datasetProjection) {
-      transformedExtent = extent;
-    } else {
-      transformedExtent = olTransformExtent(
-        extent,
-        datasetProjection,
-        mapProjection,
-      );
-    }
-  } else {
-    transformedExtent = undefined;
-  }
-
   return (
     <Tile
       id={layerId}
       source={source}
-      extent={transformedExtent}
+      extent={extent ?? undefined}
       zIndex={zIndex}
       opacity={opacity}
     />
   );
+}
+
+export function computeDatasetExtent(
+  dataset: Dataset | null,
+  mapProjection: string,
+): BBox | null {
+  if (!dataset || !dataset.geometry) {
+    return null;
+  }
+  const transformedFeature: OlFeature<OlGeometry> = new OlGeoJSONFormat({
+    dataProjection: GEOGRAPHIC_CRS,
+    featureProjection: mapProjection,
+  }).readFeature(dataset.geometry);
+  const transformedGeometry = transformedFeature.getGeometry();
+  if (!transformedGeometry) {
+    return null;
+  }
+  const transformedExtent = transformedGeometry.getExtent();
+  if (transformedExtent.length !== 4) {
+    return null;
+  }
+  return transformedExtent as BBox;
 }
 
 export const selectedDatasetBoundaryLayerSelector = createSelector(
@@ -1069,6 +1082,7 @@ export const selectedServerSelector = createSelector(
 const getVariableTileLayer = (
   server: ApiServerConfig,
   dataset: Dataset | null,
+  extent: BBox | null,
   timeLabel: string | null,
   attributions: string[] | null,
   variable: Variable | null,
@@ -1100,7 +1114,7 @@ const getVariableTileLayer = (
   return getTileLayer(
     layerId,
     getTileUrl(server.url, dataset, variable),
-    dataset.bbox,
+    extent,
     variable.tileLevelMin,
     variable.tileLevelMax,
     queryParams,
@@ -1108,7 +1122,6 @@ const getVariableTileLayer = (
     timeLabel,
     timeAnimationActive,
     mapProjection,
-    dataset.spatialRef,
     attributions,
     imageSmoothing,
     zIndex,
@@ -1118,6 +1131,7 @@ const getVariableTileLayer = (
 export const selectedDatasetVariableLayerSelector = createSelector(
   selectedServerSelector,
   selectedDatasetSelector,
+  selectedDatasetExtentSelector,
   selectedDatasetTimeLabelSelector,
   selectedDatasetAttributionsSelector,
   selectedVariableSelector,
@@ -1138,6 +1152,7 @@ export const selectedDatasetVariableLayerSelector = createSelector(
 export const selectedDatasetVariable2LayerSelector = createSelector(
   selectedServerSelector,
   selectedDataset2Selector,
+  selectedDataset2ExtentSelector,
   selectedDataset2TimeLabelSelector,
   selectedDataset2AttributionsSelector,
   selectedVariable2Selector,
@@ -1162,6 +1177,7 @@ const getDatasetRgbTileLayer = (
   visibility: boolean,
   layerId: string,
   zIndex: number,
+  extent: BBox | null,
   timeLabel: string | null,
   timeAnimationActive: boolean,
   mapProjection: string,
@@ -1175,7 +1191,7 @@ const getDatasetRgbTileLayer = (
   return getTileLayer(
     layerId,
     getTileUrl(server.url, dataset, "rgb"),
-    dataset.bbox,
+    extent,
     rgbSchema.tileLevelMin,
     rgbSchema.tileLevelMax,
     queryParams,
@@ -1183,7 +1199,6 @@ const getDatasetRgbTileLayer = (
     timeLabel,
     timeAnimationActive,
     mapProjection,
-    dataset.spatialRef,
     attributions,
     imageSmoothing,
     zIndex,
@@ -1197,6 +1212,7 @@ export const selectedDatasetRgbLayerSelector = createSelector(
   datasetRgbVisibilitySelector,
   datasetRgbLayerIdSelector,
   datasetRgbZIndexSelector,
+  selectedDatasetExtentSelector,
   selectedDatasetTimeLabelSelector,
   timeAnimationActiveSelector,
   mapProjectionSelector,
@@ -1212,6 +1228,7 @@ export const selectedDataset2RgbLayerSelector = createSelector(
   datasetRgb2VisibilitySelector,
   datasetRgb2LayerIdSelector,
   datasetRgb2ZIndexSelector,
+  selectedDataset2ExtentSelector,
   selectedDatasetTimeLabelSelector,
   timeAnimationActiveSelector,
   mapProjectionSelector,


### PR DESCRIPTION
Fixed a problem when computing the extent of variable and RGB layers.

We are now correctly using the extrema of the dataset's boundary polygon in coordinates of the viewer's map projection for the extent, rather than using the dataset's geographical bounding box. 

Closes #593
Closes #641